### PR TITLE
Handle cmigemo path

### DIFF
--- a/tools/migemo.vim
+++ b/tools/migemo.vim
@@ -21,11 +21,13 @@ function! s:SearchDict2(name)
   endif
   if dict == ''
     for path in [
-          \ '/usr/local/share/'.a:name,
-          \ '/usr/share/'.a:name,
-          \ '/usr/local/share/migemo'.a:name,
-          \ '/usr/share/cmigemo'.a:name,
+          \ '/usr/local/share/migemo/',
+          \ '/usr/local/share/cmigemo/',
+          \ '/usr/local/share/',
+          \ '/usr/share/cmigemo/',
+          \ '/usr/share/',
           \ ]
+      let path = path . a:name
       if filereadable(path)
         let dict = path
         break
@@ -38,9 +40,6 @@ endfunction
 
 function! s:SearchDict()
   let dict = ''
-  if dict == ''
-    let dict = s:SearchDict2('cmigemo/'.&encoding.'/migemo-dict')
-  endif
   if dict == ''
     let dict = s:SearchDict2('migemo/'.&encoding.'/migemo-dict')
   endif


### PR DESCRIPTION
hi

migemo.vimの辞書のパスを探す関数を少し汎用的にしました。

例えば、Ubuntuで`sudo apt-get install migemo`したときに、今まではパスがマッチしなかったんですが、この変更でmigemo辞書をちゃんと持ってくるようになります。

よろしくおねがいします。
