### PR TITLE
Update README for vim plugin use

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -9,3 +9,5 @@ LICENSE
 TODO
   See doc/TODO_j.txt (Japanese).
 
+For Vim Plugin Use
+  If you want to use this repository only as a vim plugin, use https://github.com/haya14busa/vim-migemo


### PR DESCRIPTION
text形式のまま作り直しました。
その分、リンクがURLのみになっています。
よろしくおねがいします。
