### PR TITLE
Fix: use-cpo-save

### DIFF
--- a/tools/migemo.vim
+++ b/tools/migemo.vim
@@ -5,13 +5,16 @@
 "
 " Maintainer:  MURAOKA Taro <koron@tka.att.ne.jp>
 " Modified:    Yasuhiro Matsumoto <mattn_jp@hotmail.com>
-" Last Change: 11-Dec-2013.
+" Last Change: 15-Dec-2013.
 
 " Japanese Description:
 
 if exists('plugin_migemo_disable')
   finish
 endif
+
+let s:save_cpo = &cpo
+set cpo&vim
 
 function! s:SearchDict2(name)
   let path = $VIM . ',' . &runtimepath
@@ -98,3 +101,6 @@ else
     endif
   endfunction
 endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
この前のpathを柔軟にするプルリクの際に行連結をつかったさい、http://vim-jp.org/vimdoc-ja/usr_41.html#use-cpo-save
の副作用の回避をするべきでした。

実際にエラーの再現はしていませんが、helpを読む限り必要なようです。よろしくおねがいします。
