### PR TITLE
Fix Emacs space-or-newline regexp

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -178,7 +178,7 @@ main(int argc, char** argv)
 	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_IN, "\\(");
 	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
 	    if (!mode_nonewline)
-		migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
+		migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "[[:space:]\r\n]*");
 	}
 #ifndef _PROFILE
 	if (word)

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -22,7 +22,7 @@
 #define RXGEN_ENC_SJISTINY
 //#define RXGEN_OP_VIM
 
-#define RXGEN_OP_MAXLEN 8
+#define RXGEN_OP_MAXLEN 16
 #define RXGEN_OP_OR "|"
 #define RXGEN_OP_NEST_IN "("
 #define RXGEN_OP_NEST_OUT ")"


### PR DESCRIPTION
空白及び改行にマッチする Emacs Lispの正規表現が空白文字にしかマッチ
しなかったので, 改行にもマッチするよう修正しました.

レビューのほどよろしくお願いします.
