### PR TITLE
Revert "Fix Emacs space-or-newline regexp"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -178,7 +178,7 @@ main(int argc, char** argv)
 	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_IN, "\\(");
 	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
 	    if (!mode_nonewline)
-		migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "[[:space:]\r\n]*");
+		migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
 	}
 #ifndef _PROFILE
 	if (word)

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -22,7 +22,7 @@
 #define RXGEN_ENC_SJISTINY
 //#define RXGEN_OP_VIM
 
-#define RXGEN_OP_MAXLEN 16
+#define RXGEN_OP_MAXLEN 8
 #define RXGEN_OP_OR "|"
 #define RXGEN_OP_NEST_IN "("
 #define RXGEN_OP_NEST_OUT ")"


### PR DESCRIPTION
HEAD では C/Migemo の返すパターンの中に `\n` が含まれるようになっていますが、migemo.el で `\n`  をパターンの終端判定に使っているためパターンが壊れることがあります。

http://0xcc.net/migemo/ の

> Emacs の "\s " の意味はモードによって変わります。モードによっては行をまたぐ検索ができないことがあります。

という動作に戻ります。
