### PR TITLE
add zya行 to roma2hira table.

### DIFF
--- a/dict/roma2hira.dat
+++ b/dict/roma2hira.dat
@@ -275,6 +275,12 @@ jyu	‚¶‚ã
 jye	‚¶‚¥
 jyo	‚¶‚å
 
+zya	‚¶‚á
+zyi	‚¶‚¡
+zyu	‚¶‚ã
+zye	‚¶‚¥
+zyo	‚¶‚å
+
 qa	‚­‚Ÿ
 qi	‚­‚¡
 qu	‚­


### PR DESCRIPTION
じゃ、じゅ、じょ を zya,zyu,zyo で入力しているのですが、変換表に無かったので追加しました。
zyi、zyeの方は、変換表の他の所を見ると入っているようなので入れてあります。