### PR TITLE
Dynamically refer to prefix as rpath when a user compiles shared object.

### DIFF
--- a/compile/Make_gcc.mak
+++ b/compile/Make_gcc.mak
@@ -14,7 +14,7 @@ libmigemo_DSO	= libmigemo.so.1
 libmigemo	= libmigemo.so
 EXEEXT		=
 CFLAGS_MIGEMO	= -fPIC
-LDFLAGS_MIGEMO	= -Wl,-rpath,.,-rpath,/usr/local/lib,-rpath,/usr/lib
+LDFLAGS_MIGEMO	= -Wl,-rpath,.,-rpath,/usr/lib
 
 include config.mk
 include compile/unix.mak

--- a/compile/unix.mak
+++ b/compile/unix.mak
@@ -11,7 +11,7 @@ libmigemo_OBJ = $(OBJ)
 
 DEFINES	=
 CFLAGS	= -O2 -Wall $(DEFINES) $(CFLAGS_MIGEMO)
-LDFLAGS = $(LDFLAGS_MIGEMO)
+LDFLAGS = -Wl,-rpath,$(prefix)/lib $(LDFLAGS_MIGEMO)
 LIBS	= 
 
 default: dirs $(outdir)cmigemo$(EXEEXT)


### PR DESCRIPTION
## [problem report #Invalid reference to a shared library.]
## [Proposed solution #Dynamically refer to prefix as rpath when a user compiles.]

Hi, koron. Nice to see you again. 
Now I have compiled cmigemo on "Ubuntu 14.04.2 LTS" 
with --prefix=$HOME/local .
Then tried to use it on my Emacs, but only to have failed.
I checked details as follows and figured out the reference to dynamic library 'libmigemo.so.1' is invalid.

----------------from here --------------------
$ cd CMIGEMODIR
$ ./configure --prefix=$HOME/local
$ make gcc-all && make gcc-install
$ cd
$ cmigemo
cmigemo: error while loading shared libraries: libmigemo.so.1: cannot open shared object file: No such file or directory

$ ldd ~/local/bin/cmigemo
        linux-gate.so.1 =>  (0xb7722000)
        libmigemo.so.1 => not found
        libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xb7555000)
        /lib/ld-linux.so.2 (0xb7723000)

## We can try a workaround plan of course.
$ env LD_LIBRARY_PATH=$HOME/local/lib cmigemo -d ~/local/share/migemo/utf-8/migemo-dict 
migemo_open("/home/aki/local/share/migemo/utf-8/migemo-dict")=0x9acc008
clock()=0.306410
QUERY: ai
PATTERN: ([会姶藹哀阨饗欸挨靉噫愛隘瞹合埃娃藍穢曖間相]|ｱｲ|吾平|文色|E(s|insteinium)|粟飯原|生憎|彼奴|匕首|英田|鮎([並川]|魚女)|靄[々靄]|逢([引妻]|い引き)|I(P(電話|アドレス)|Dカード|C(タグ|カード))|Ｉ(Ｐ電話|Ｃ(タグ|カード))|亜衣|あい|ａｉ|ＡＩエキスパート|後天性免疫不全症候群|ア(イ|ーイシャ)|エ([メア]|イ([ムドズ]|ミング)|ー(メ|ルフランス))|人工知能|AI|ai)
QUERY:

----------------ends here --------------------

The main cause of this is I have used the option '--prefix'.
I propose that It's better to change rpath as my changes for user-friendliness.
Please consider, thanks.