### PR TITLE
chage SKKDIC_BASEURL

### DIFF
--- a/dict/dict.mak
+++ b/dict/dict.mak
@@ -6,7 +6,7 @@
 
 DICT 		= migemo-dict
 DICT_BASE	= base-dict
-SKKDIC_BASEURL 	= http://openlab.ring.gr.jp/skk/dic
+SKKDIC_BASEURL 	= https://skk-dev.github.io/dict
 SKKDIC_FILE	= SKK-JISYO.L
 EUCJP_DIR	= euc-jp.d
 UTF8_DIR	= utf-8.d


### PR DESCRIPTION
github の辞書ファイルは時折メンテしていますが、
それを openlab 側には反映していませんので、
`SKKDIC_BASEURL` は github としたいです。