### PR TITLE
Add directory dependencies to fix parallel builds

### DIFF
--- a/dict/dict.mak
+++ b/dict/dict.mak
@@ -33,40 +33,40 @@ cp932:		$(DICT)
 # Dictionary in euc-jp
 #
 euc-jp: 	cp932 euc-jp-files
-euc-jp-files: $(EUCJP_DIR) $(EUCJP_DIR)/migemo-dict \
+euc-jp-files: $(EUCJP_DIR)/migemo-dict \
 	$(EUCJP_DIR)/zen2han.dat $(EUCJP_DIR)/han2zen.dat \
 	$(EUCJP_DIR)/hira2kata.dat $(EUCJP_DIR)/roma2hira.dat
 $(EUCJP_DIR):
 	$(MKDIR) $(EUCJP_DIR)
-$(EUCJP_DIR)/migemo-dict: migemo-dict
+$(EUCJP_DIR)/migemo-dict: $(EUCJP_DIR) migemo-dict
 	$(FILTER_EUCJP) < migemo-dict > $@
-$(EUCJP_DIR)/zen2han.dat: zen2han.dat
+$(EUCJP_DIR)/zen2han.dat: $(EUCJP_DIR) zen2han.dat
 	$(FILTER_EUCJP) < zen2han.dat > $@
-$(EUCJP_DIR)/han2zen.dat: han2zen.dat
+$(EUCJP_DIR)/han2zen.dat: $(EUCJP_DIR) han2zen.dat
 	$(FILTER_EUCJP) < han2zen.dat > $@
-$(EUCJP_DIR)/hira2kata.dat: hira2kata.dat
+$(EUCJP_DIR)/hira2kata.dat: $(EUCJP_DIR) hira2kata.dat
 	$(FILTER_EUCJP) < hira2kata.dat > $@
-$(EUCJP_DIR)/roma2hira.dat: roma2hira.dat
+$(EUCJP_DIR)/roma2hira.dat: $(EUCJP_DIR) roma2hira.dat
 	$(FILTER_EUCJP) < roma2hira.dat > $@
 
 ##############################################################################
 # Dictionary in utf-8
 #
 utf-8: 	cp932 utf-8-files
-utf-8-files: $(UTF8_DIR) $(UTF8_DIR)/migemo-dict \
+utf-8-files: $(UTF8_DIR)/migemo-dict \
 	$(UTF8_DIR)/zen2han.dat $(UTF8_DIR)/han2zen.dat \
 	$(UTF8_DIR)/hira2kata.dat $(UTF8_DIR)/roma2hira.dat
 $(UTF8_DIR):
 	$(MKDIR) $(UTF8_DIR)
-$(UTF8_DIR)/migemo-dict: migemo-dict
+$(UTF8_DIR)/migemo-dict: $(UTF8_DIR) migemo-dict
 	$(FILTER_UTF8) < migemo-dict > $@
-$(UTF8_DIR)/zen2han.dat: zen2han.dat
+$(UTF8_DIR)/zen2han.dat: $(UTF8_DIR) zen2han.dat
 	$(FILTER_UTF8) < zen2han.dat > $@
-$(UTF8_DIR)/han2zen.dat: han2zen.dat
+$(UTF8_DIR)/han2zen.dat: $(UTF8_DIR) han2zen.dat
 	$(FILTER_UTF8) < han2zen.dat > $@
-$(UTF8_DIR)/hira2kata.dat: hira2kata.dat
+$(UTF8_DIR)/hira2kata.dat: $(UTF8_DIR) hira2kata.dat
 	$(FILTER_UTF8) < hira2kata.dat > $@
-$(UTF8_DIR)/roma2hira.dat: roma2hira.dat
+$(UTF8_DIR)/roma2hira.dat: $(UTF8_DIR) roma2hira.dat
 	$(FILTER_UTF8) < roma2hira.dat > $@
 
 ##############################################################################


### PR DESCRIPTION
When building in parallel (make -j) sometimes make would try to create a dictionary file before the directory containing it had been created.  To fix this, I've made the directory a dependency of each file in it, rather than having them be sibling dependencies of the -files targets.
