### PR TITLE
Parallel install fixes discovered by make --shuffle

### DIFF
--- a/compile/unix.mak
+++ b/compile/unix.mak
@@ -45,7 +45,7 @@ install-mkdir:
 	$(MKDIR) $(dictdir)/euc-jp
 	$(MKDIR) $(dictdir)/utf-8
 
-install-dict:
+install-dict: install-mkdir
 	$(INSTALL_DATA) dict/migemo-dict $(dictdir)/cp932
 	$(INSTALL_DATA) dict/han2zen.dat $(dictdir)/cp932
 	$(INSTALL_DATA) dict/hira2kata.dat $(dictdir)/cp932

--- a/compile/unix.mak
+++ b/compile/unix.mak
@@ -14,7 +14,7 @@ CFLAGS	= -O2 -Wall $(DEFINES) $(CFLAGS_MIGEMO)
 LDFLAGS = $(LDFLAGS_MIGEMO)
 LIBS	= 
 
-default: dirs $(outdir)cmigemo$(EXEEXT)
+default: $(outdir)cmigemo$(EXEEXT)
 
 dirs:
 	@for i in $(objdir) $(outdir); do \
@@ -26,10 +26,10 @@ dirs:
 $(outdir)cmigemo$(EXEEXT): $(objdir)main.$(O) $(libmigemo_LIB)
 	$(CC) -o $@ $(objdir)main.$(O) -L. -L$(outdir) -lmigemo $(LDFLAGS)
 
-$(objdir)main.o: $(srcdir)main.c
+$(objdir)main.o: $(srcdir)main.c dirs
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-$(objdir)%.o: $(srcdir)%.c
+$(objdir)%.o: $(srcdir)%.c dirs
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 ##############################################################################

--- a/compile/unix.mak
+++ b/compile/unix.mak
@@ -66,6 +66,9 @@ install-dict: install-mkdir
 	  $(INSTALL_DATA) dict/utf-8.d/zen2han.dat $(dictdir)/utf-8; \
 	fi
 
+# depends on $(libdir) to be already present
+install-lib: install-mkdir
+
 install: $(outdir)cmigemo$(EXEEXT) $(libmigemo_DSO) install-mkdir install-dict install-lib
 	$(INSTALL_DATA) $(srcdir)migemo.h $(incdir)
 	$(INSTALL_DATA) doc/README_j.txt $(docdir)


### PR DESCRIPTION
git GNU make got a new `--shuffle` option recently: https://savannah.gnu.org/bugs/index.php?62100

It allows exposing various race conditions in Makefiles. This pull request fixes 3 of them I found over a few runs:
- compile/unix.mak: add .o file dependency on $(objdir) directory
- compile/unix.mak: add install dependency on $(dictdir) directory
- compile/unix.mak: add install-lib dependency on $(libdir) directory

All fixes are dependency fixes (missing directory creation ordering) and nothing more.

Before fixes were applied `make --shuffle` was failing on every second build/install attempt.
After the fixes applied I saw no failures after 100 runs build/install attempts.