### PR TITLE
revert: restore curl usage for downloading dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Or just `rm -rf build`.
     -   C11 compiler and binutils equivalents (gcc, clang, msvc or so)
 -   Building the dictionary
     -   CMake (3.16 or above)
+    -   curl
     -   iconv
     -   gzip
     -   perl

--- a/dict/CMakeLists.txt
+++ b/dict/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Perl REQUIRED)
 
 #------------------------------------------------------------------------------
 # Detect required commands: curl, iconv, gzip
+find_program(CURL_EXECUTABLE curl REQUIRED)
 find_program(ICONV_EXECUTABLE iconv REQUIRED)
 find_program(GZIP_EXECUTABLE gzip REQUIRED)
 
@@ -28,10 +29,7 @@ set_property(
 # Download SKK-JISYO.L
 add_custom_command(
   OUTPUT ${SKKDICT_PATH}
-  COMMAND
-    ${CMAKE_COMMAND} -DURL="${SKKDICT_BASEURL}/${SKKDICT_FILE}.gz"
-    -DOUTPUT_PATH="${CMAKE_CURRENT_BINARY_DIR}/${SKKDICT_FILE}.gz" -P
-    "${CMAKE_CURRENT_SOURCE_DIR}/download.cmake"
+  COMMAND ${CURL_EXECUTABLE} -fsSLO "${SKKDICT_BASEURL}/${SKKDICT_FILE}.gz"
   COMMAND ${GZIP_EXECUTABLE} -d "${SKKDICT_FILE}.gz"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Downloading and extracting ${SKKDICT_FILE}")
@@ -52,8 +50,6 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Converting ${SKKDICT_FILE} to UTF-8")
 
-add_custom_target(fetch_skkdict DEPENDS ${SKKDICT_UTF8_PATH})
-
 #------------------------------------------------------------------------------
 # Generate C/Migemo dictionary file (migemo-dict).
 add_custom_command(
@@ -70,6 +66,8 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/optimize-dict.pl
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating base migemo-dict")
+
+add_custom_target(generate_base_dict DEPENDS ${BASE_DICT_PATH})
 
 #------------------------------------------------------------------------------
 # A helper function that generates a dictionary for the specified encoding.
@@ -185,7 +183,7 @@ function(add_dict_encoding_target ENCODING_NAME ICONV_ENCODING IGNORE_ERROR)
   # Custom targeting for registration to the overall target
   add_custom_target(dict_${ENCODING_NAME} ALL DEPENDS ${OUT_DICT})
 
-  add_dependencies(dict_${ENCODING_NAME} fetch_skkdict)
+  add_dependencies(dict_${ENCODING_NAME} generate_base_dict)
 
   install(
     DIRECTORY "${OUT_DIR}/"

--- a/dict/download.cmake
+++ b/dict/download.cmake
@@ -1,8 +1,0 @@
-if(NOT EXISTS "${OUTPUT_PATH}")
-  message(STATUS "Downloading ${URL}...")
-  file(DOWNLOAD "${URL}" "${OUTPUT_PATH}" STATUS DOWNLOAD_STATUS)
-  list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
-  if(NOT STATUS_CODE EQUAL 0)
-    message(FATAL_ERROR "Failed to download: ${DOWNLOAD_STATUS}")
-  endif()
-endif()

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -34,6 +34,8 @@ if(GPROF_EXECUTABLE AND CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
   target_compile_options(qspeed PRIVATE -O0 -pg)
   target_link_options(qspeed PRIVATE -O0 -pg)
 
+  add_dependencies(qspeed dict_utf-8)
+
   add_custom_target(
     profile
     COMMAND $<TARGET_FILE:qspeed>


### PR DESCRIPTION
Replace CMake's `file(DOWNLOAD)` back with `curl` execution. `file(DOWNLOAD)` does not fail on HTTP errors (e.g. 404/302 redirects), causing invalid HTML content to be downloaded as a gzipped file, which subsequently broke iconv conversion during the build.

Using `curl -fsSLO` ensures proper error handling on HTTP failures and automatic redirect following.

Additionally:
- Remove unused `download.cmake` script.
- Remove redundant intermediate target `fetch_skkdict` and its target-level dependencies, relying instead on clean file-level DAG dependencies.
- Update `README.md` to list `curl` as a requirement.