### PR TITLE
perf(rxgen): optimize rnode search with move-to-front algorithm

### DIFF
--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -167,11 +167,21 @@ rxgen_close(rxgen* object)
 }
 
     static rnode*
-search_rnode(rnode* node, unsigned int code)
+search_rnode(rnode** phead, unsigned int code)
 {
-    while (node && node->code != code)
-	node = node->next;
-    return node;
+    rnode **pp = phead;
+    while (*pp && (*pp)->code != code)
+	pp = &(*pp)->next;
+
+    if (*pp && pp != phead)
+    {
+	rnode *found = *pp;
+	*pp = found->next;
+	found->next = *phead;
+	*phead = found;
+	return found;
+    }
+    return *pp;
 }
 
     int
@@ -201,7 +211,7 @@ rxgen_add(rxgen* object, const unsigned char* word)
 	    }
 	    break;
 	}
-	pnode = search_rnode(*ppnode, code);
+	pnode = search_rnode(ppnode, code);
 	if (pnode == NULL)
 	{
 	    // codeを持つノードが無い場合、作成追加する

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,3 +10,10 @@ add_test(NAME test_migemo1 COMMAND test1)
 set_tests_properties(
   test_migemo1
   PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
+
+#------------------------------------------------------------------------------
+
+add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS test1
+)


### PR DESCRIPTION
Implement Move-To-Front (MTF) algorithm in `search_rnode()` to optimize linear search performance during `rxgen_add()`. Hits are moved to the head of the node list, reducing search overhead for repeated prefixes without additional memory allocation.

Also add a `check` custom target to `test/CMakeLists.txt` for easier test execution via ctest.