### PR TITLE
Introduce clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,40 @@ IndentWidth: 4
 TabWidth: 8
 UseTab: Never
 ColumnLimit: 80
+
+BreakAfterReturnType: AllDefinitions
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  #IndentBraces: true
+  #SplitEmptyFunction: true
+  #SplitEmptyRecord: true
+  #SplitEmptyNamespace: true
+
+BreakBeforeBinaryOperators: NonAssignment
+
+IndentPPDirectives: AfterHash
+PPIndentWidth: 1
+
+IndentCaseLabels: true
+
+IndentExternBlock: NoIndent
+
+ContinuationIndentWidth: 8
+AlignAfterOpenBracket: false
+
+AlignConsecutiveMacros: Consecutive

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+Language: C
+
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+TabWidth: 8
+UseTab: Never
+ColumnLimit: 80

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
-# vi:set ts=8 sts=8 sw=8 tw=0:
+# vim:set ts=8 sts=8 sw=8 tw=0 noet:
 #
 # C/Migemo Makefile
 
-.PHONY: build package tags clean distclean
+.PHONY: build tags format package clean distclean
 
 build:
 	cmake -B build
 	cmake --build build --parallel
 
+tags: src/*.c src/*.h
+	ctags src/*.c src/*.h
+
+format:
+	find . -type f \( -name "*.c" -o -name "*.h" \) | xargs clang-format -i
+
 package:
 	cmake -B build -DCMAKE_BUILD_TYPE=Release
 	cmake --build build --target package --config Release --parallel
-
-tags: src/*.c src/*.h
-	ctags src/*.c src/*.h
 
 clean:
 	@if [ -d build ]; then cmake --build build --target clean 2>/dev/null || true; fi

--- a/src/charset.c
+++ b/src/charset.c
@@ -1,191 +1,192 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // charset.c -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
 #define BUFLEN_DETECT 4096
 
-#include <stdio.h>
 #include <limits.h>
+#include <stdio.h>
+
 #include "charset.h"
 
-    int
-cp932_char2int(const unsigned char* in, unsigned int* out)
+int
+cp932_char2int(const unsigned char *in, unsigned int *out)
 {
-    if (((0x81 <= in[0] && in[0] <= 0x9f)
-		|| (0xe0 <= in[0] && in[0] <= 0xf0))
-	    && ((0x40 <= in[1] && in[1] <= 0x7e)
-		|| (0x80 <= in[1] && in[1] <= 0xfc)))
+    if (((0x81 <= in[0] && in[0] <= 0x9f) || (0xe0 <= in[0] && in[0] <= 0xf0))
+            && ((0x40 <= in[1] && in[1] <= 0x7e)
+                    || (0x80 <= in[1] && in[1] <= 0xfc)))
     {
-	if (out)
-	    *out = (unsigned int)in[0] << 8 | (unsigned int)in[1];
-	return 2;
+        if (out)
+            *out = (unsigned int)in[0] << 8 | (unsigned int)in[1];
+        return 2;
     }
     else
     {
-	if (out)
-	    *out = in[0];
-	return 1;
+        if (out)
+            *out = in[0];
+        return 1;
     }
 }
 
-    int
-cp932_int2char(unsigned int in, unsigned char* out)
+int
+cp932_int2char(unsigned int in, unsigned char *out)
 {
     if (in >= 0x100)
     {
-	if (out)
-	{
-	    out[0] = (unsigned char)((in >> 8) & 0xFF);
-	    out[1] = (unsigned char)(in & 0xFF);
-	}
-	return 2;
+        if (out)
+        {
+            out[0] = (unsigned char)((in >> 8) & 0xFF);
+            out[1] = (unsigned char)(in & 0xFF);
+        }
+        return 2;
     }
     else
-	return 0;
+        return 0;
 }
 
 #define IS_EUC_RANGE(c) (0xa1 <= (c) && (c) <= 0xfe)
 
-    int
-eucjp_char2int(const unsigned char* in, unsigned int* out)
+int
+eucjp_char2int(const unsigned char *in, unsigned int *out)
 {
     if ((in[0] == 0x8e && 0xa0 <= in[1] && in[1] <= 0xdf)
-	    || (IS_EUC_RANGE(in[0]) && IS_EUC_RANGE(in[1])))
+            || (IS_EUC_RANGE(in[0]) && IS_EUC_RANGE(in[1])))
     {
-	if (out)
-	    *out = (unsigned int)in[0] << 8 | (unsigned int)in[1];
-	return 2;
+        if (out)
+            *out = (unsigned int)in[0] << 8 | (unsigned int)in[1];
+        return 2;
     }
     else
     {
-	if (out)
-	    *out = in[0];
-	return 1;
+        if (out)
+            *out = in[0];
+        return 1;
     }
 }
 
-    int
-eucjp_int2char(unsigned int in, unsigned char* out)
+int
+eucjp_int2char(unsigned int in, unsigned char *out)
 {
     // CP932と内容は同じだが将来JISX0213に対応させるために分離しておく
     if (in >= 0x100)
     {
-	if (out)
-	{
-	    out[0] = (unsigned char)((in >> 8) & 0xFF);
-	    out[1] = (unsigned char)(in & 0xFF);
-	}
-	return 2;
+        if (out)
+        {
+            out[0] = (unsigned char)((in >> 8) & 0xFF);
+            out[1] = (unsigned char)(in & 0xFF);
+        }
+        return 2;
     }
     else
-	return 0;
+        return 0;
 }
 
-    static int
-utf8_char2int_noascii(const unsigned char* in, unsigned int* out)
+static int
+utf8_char2int_noascii(const unsigned char *in, unsigned int *out)
 {
     int len = 0;
     int i;
     unsigned int ch;
 
     for (ch = in[0]; ch & 0x80; ch <<= 1)
-	++len;
-    //printf("len=%d in=%s\n", len, in);
+        ++len;
+    // printf("len=%d in=%s\n", len, in);
     if (len < 2)
-	return 0;
+        return 0;
     ch = (ch & 0xff) >> len;
     for (i = 1; i < len; ++i)
     {
-	if ((in[i] & 0xc0) != 0x80)
-	    return 0;
-	ch <<= 6;
-	ch += in[i] & 0x3f;
+        if ((in[i] & 0xc0) != 0x80)
+            return 0;
+        ch <<= 6;
+        ch += in[i] & 0x3f;
     }
-    //printf("len=%d in=%s ch=%08x\n", len, in, ch);
+    // printf("len=%d in=%s ch=%08x\n", len, in, ch);
     if (out)
-	*out = ch;
+        *out = ch;
     return len;
 }
 
-    int
-utf8_char2int(const unsigned char* in, unsigned int* out)
+int
+utf8_char2int(const unsigned char *in, unsigned int *out)
 {
     int retval = utf8_char2int_noascii(in, out);
     if (retval)
-	return retval;
+        return retval;
     else
     {
-	if (out)
-	    *out = in[0];
-	return 1;
+        if (out)
+            *out = in[0];
+        return 1;
     }
 }
 
-    int
-utf8_int2char(unsigned int in, unsigned char* out)
+int
+utf8_int2char(unsigned int in, unsigned char *out)
 {
     if (in < 0x80)
-	return 0;
+        return 0;
     if (in < 0x800)
     {
-	if (out)
-	{
-	    out[0] = 0xc0 + (in >> 6);
-	    out[1] = 0x80 + ((in >> 0) & 0x3f);
-	}
-	return 2;
+        if (out)
+        {
+            out[0] = 0xc0 + (in >> 6);
+            out[1] = 0x80 + ((in >> 0) & 0x3f);
+        }
+        return 2;
     }
     if (in < 0x10000)
     {
-	if (out)
-	{
-	    out[0] = 0xe0 + (in >> 12);
-	    out[1] = 0x80 + ((in >> 6) & 0x3f);
-	    out[2] = 0x80 + ((in >> 0) & 0x3f);
-	}
-	return 3;
+        if (out)
+        {
+            out[0] = 0xe0 + (in >> 12);
+            out[1] = 0x80 + ((in >> 6) & 0x3f);
+            out[2] = 0x80 + ((in >> 0) & 0x3f);
+        }
+        return 3;
     }
     if (in < 0x200000)
     {
-	if (out)
-	{
-	    out[0] = 0xf0 + (in >> 18);
-	    out[1] = 0x80 + ((in >> 12) & 0x3f);
-	    out[2] = 0x80 + ((in >> 6) & 0x3f);
-	    out[3] = 0x80 + ((in >> 0) & 0x3f);
-	}
-	return 4;
+        if (out)
+        {
+            out[0] = 0xf0 + (in >> 18);
+            out[1] = 0x80 + ((in >> 12) & 0x3f);
+            out[2] = 0x80 + ((in >> 6) & 0x3f);
+            out[3] = 0x80 + ((in >> 0) & 0x3f);
+        }
+        return 4;
     }
     if (in < 0x4000000)
     {
-	if (out)
-	{
-	    out[0] = 0xf8 + (in >> 24);
-	    out[1] = 0x80 + ((in >> 18) & 0x3f);
-	    out[2] = 0x80 + ((in >> 12) & 0x3f);
-	    out[3] = 0x80 + ((in >> 6) & 0x3f);
-	    out[4] = 0x80 + ((in >> 0) & 0x3f);
-	}
-	return 5;
+        if (out)
+        {
+            out[0] = 0xf8 + (in >> 24);
+            out[1] = 0x80 + ((in >> 18) & 0x3f);
+            out[2] = 0x80 + ((in >> 12) & 0x3f);
+            out[3] = 0x80 + ((in >> 6) & 0x3f);
+            out[4] = 0x80 + ((in >> 0) & 0x3f);
+        }
+        return 5;
     }
     else
     {
-	if (out)
-	{
-	    out[0] = 0xf8 + (in >> 30);
-	    out[1] = 0x80 + ((in >> 24) & 0x3f);
-	    out[2] = 0x80 + ((in >> 18) & 0x3f);
-	    out[3] = 0x80 + ((in >> 12) & 0x3f);
-	    out[4] = 0x80 + ((in >> 6) & 0x3f);
-	    out[5] = 0x80 + ((in >> 0) & 0x3f);
-	}
-	return 6;
+        if (out)
+        {
+            out[0] = 0xf8 + (in >> 30);
+            out[1] = 0x80 + ((in >> 24) & 0x3f);
+            out[2] = 0x80 + ((in >> 18) & 0x3f);
+            out[3] = 0x80 + ((in >> 12) & 0x3f);
+            out[4] = 0x80 + ((in >> 6) & 0x3f);
+            out[5] = 0x80 + ((in >> 0) & 0x3f);
+        }
+        return 6;
     }
 }
 
-    int
-charset_detect_buf(const unsigned char* buf, int len)
+int
+charset_detect_buf(const unsigned char *buf, int len)
 {
     int sjis = 0, smode = 0;
     int euc = 0, emode = 0, eflag = 0;
@@ -193,120 +194,120 @@ charset_detect_buf(const unsigned char* buf, int len)
     int i;
     for (i = 0; i < len; ++i)
     {
-	unsigned char c = buf[i];
-	// SJISであるかのチェック
-	if (smode)
-	{
-	    if ((0x40 <= c && c <= 0x7e) || (0x80 <= c && c <= 0xfc))
-		++sjis;
-	    smode = 0;
-	}
-	else if ((0x81 <= c && c <= 0x9f) || (0xe0 <= c && c <= 0xf0))
-	    smode = 1;
-	// EUCであるかのチェック
-	eflag = 0xa1 <= c && c <= 0xfe;
-	if (emode)
-	{
-	    if (eflag)
-		++euc;
-	    emode = 0;
-	}
-	else if (eflag)
-	    emode = 1;
-	// UTF8であるかのチェック
-	if (!ufailed)
-	{
-	    if (umode < 1)
-	    {
-		if ((c & 0x80) != 0)
-		{
-		    if ((c & 0xe0) == 0xc0)
-			umode = 1;
-		    else if ((c & 0xf0) == 0xe0)
-			umode = 2;
-		    else if ((c & 0xf8) == 0xf0)
-			umode = 3;
-		    else if ((c & 0xfc) == 0xf8)
-			umode = 4;
-		    else if ((c & 0xfe) == 0xfc)
-			umode = 5;
-		    else
-		    {
-			ufailed = 1;
-			--utf8;
-		    }
-		}
-	    }
-	    else
-	    {
-		if ((c & 0xc0) == 0x80)
-		{
-		    ++utf8;
-		    --umode;
-		}
-		else
-		{
-		    --utf8;
-		    umode = 0;
-		    ufailed = 1;
-		}
-	    }
-	    if (utf8 < 0)
-		utf8 = 0;
-	}
+        unsigned char c = buf[i];
+        // SJISであるかのチェック
+        if (smode)
+        {
+            if ((0x40 <= c && c <= 0x7e) || (0x80 <= c && c <= 0xfc))
+                ++sjis;
+            smode = 0;
+        }
+        else if ((0x81 <= c && c <= 0x9f) || (0xe0 <= c && c <= 0xf0))
+            smode = 1;
+        // EUCであるかのチェック
+        eflag = 0xa1 <= c && c <= 0xfe;
+        if (emode)
+        {
+            if (eflag)
+                ++euc;
+            emode = 0;
+        }
+        else if (eflag)
+            emode = 1;
+        // UTF8であるかのチェック
+        if (!ufailed)
+        {
+            if (umode < 1)
+            {
+                if ((c & 0x80) != 0)
+                {
+                    if ((c & 0xe0) == 0xc0)
+                        umode = 1;
+                    else if ((c & 0xf0) == 0xe0)
+                        umode = 2;
+                    else if ((c & 0xf8) == 0xf0)
+                        umode = 3;
+                    else if ((c & 0xfc) == 0xf8)
+                        umode = 4;
+                    else if ((c & 0xfe) == 0xfc)
+                        umode = 5;
+                    else
+                    {
+                        ufailed = 1;
+                        --utf8;
+                    }
+                }
+            }
+            else
+            {
+                if ((c & 0xc0) == 0x80)
+                {
+                    ++utf8;
+                    --umode;
+                }
+                else
+                {
+                    --utf8;
+                    umode = 0;
+                    ufailed = 1;
+                }
+            }
+            if (utf8 < 0)
+                utf8 = 0;
+        }
     }
     // 最終的に一番得点の高いエンコードを返す
     if (euc > sjis && euc > utf8)
-	return CHARSET_EUCJP;
+        return CHARSET_EUCJP;
     else if (!ufailed && utf8 > euc && utf8 > sjis)
-	return CHARSET_UTF8;
+        return CHARSET_UTF8;
     else if (sjis > euc && sjis > utf8)
-	return CHARSET_CP932;
+        return CHARSET_CP932;
     else
-	return CHARSET_NONE;
+        return CHARSET_NONE;
 }
 
-    void
-charset_getproc(int charset, CHARSET_PROC_CHAR2INT* char2int,
-	CHARSET_PROC_INT2CHAR* int2char)
+void
+charset_getproc(int charset, CHARSET_PROC_CHAR2INT *char2int,
+        CHARSET_PROC_INT2CHAR *int2char)
 {
     CHARSET_PROC_CHAR2INT c2i = NULL;
     CHARSET_PROC_INT2CHAR i2c = NULL;
     switch (charset)
     {
-	case CHARSET_CP932:
-	    c2i = cp932_char2int;
-	    i2c = cp932_int2char;
-	    break;
-	case CHARSET_EUCJP:
-	    c2i = eucjp_char2int;
-	    i2c = eucjp_int2char;
-	    break;
-	case CHARSET_UTF8:
-	    c2i = utf8_char2int;
-	    i2c = utf8_int2char;
-	    break;
-	default:
-	    break;
+        case CHARSET_CP932:
+            c2i = cp932_char2int;
+            i2c = cp932_int2char;
+            break;
+        case CHARSET_EUCJP:
+            c2i = eucjp_char2int;
+            i2c = eucjp_int2char;
+            break;
+        case CHARSET_UTF8:
+            c2i = utf8_char2int;
+            i2c = utf8_int2char;
+            break;
+        default:
+            break;
     }
     if (char2int)
-	*char2int = c2i;
+        *char2int = c2i;
     if (int2char)
-	*int2char = i2c;
+        *int2char = i2c;
 }
 
-    int
-charset_detect_file(const char* path)
+int
+charset_detect_file(const char *path)
 {
     int charset = CHARSET_NONE;
-    FILE* fp;
+    FILE *fp;
     if ((fp = fopen(path, "rt")) != NULL)
     {
-	unsigned char buf[BUFLEN_DETECT];
-	size_t len = fread(buf, sizeof(buf[0]), sizeof(buf), fp);
-	fclose(fp);
-	if (len > 0 && len <= INT_MAX)
-	    charset = charset_detect_buf(buf, (int)len);
+        unsigned char buf[BUFLEN_DETECT];
+        size_t len = fread(buf, sizeof(buf[0]), sizeof(buf), fp);
+        fclose(fp);
+        if (len > 0 && len <= INT_MAX)
+            charset = charset_detect_buf(buf, (int)len);
     }
     return charset;
 }

--- a/src/charset.h
+++ b/src/charset.h
@@ -1,10 +1,11 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // charset.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
 #ifndef CHARSET_H
-# define CHARSET_H
+#define CHARSET_H
 
 enum {
     CHARSET_NONE = 0,
@@ -13,8 +14,8 @@ enum {
     CHARSET_UTF8 = 3,
 };
 
-typedef int (*charset_proc_char2int)(const unsigned char*, unsigned int*);
-typedef int (*charset_proc_int2char)(unsigned int, unsigned char*);
+typedef int (*charset_proc_char2int)(const unsigned char *, unsigned int *);
+typedef int (*charset_proc_int2char)(unsigned int, unsigned char *);
 #define CHARSET_PROC_CHAR2INT charset_proc_char2int
 #define CHARSET_PROC_INT2CHAR charset_proc_int2char
 
@@ -22,17 +23,17 @@ typedef int (*charset_proc_int2char)(unsigned int, unsigned char*);
 extern "C" {
 #endif
 
-int cp932_char2int(const unsigned char* in, unsigned int* out);
-int cp932_int2char(unsigned int in, unsigned char* out);
-int eucjp_char2int(const unsigned char* in, unsigned int* out);
-int eucjp_int2char(unsigned int in, unsigned char* out);
-int utf8_char2int(const unsigned char* in, unsigned int* out);
-int utf8_int2char(unsigned int in, unsigned char* out);
+int cp932_char2int(const unsigned char *in, unsigned int *out);
+int cp932_int2char(unsigned int in, unsigned char *out);
+int eucjp_char2int(const unsigned char *in, unsigned int *out);
+int eucjp_int2char(unsigned int in, unsigned char *out);
+int utf8_char2int(const unsigned char *in, unsigned int *out);
+int utf8_int2char(unsigned int in, unsigned char *out);
 
-int charset_detect_file(const char* path);
-int charset_detect_buf(const unsigned char* buf, int len);
-void charset_getproc(int charset, CHARSET_PROC_CHAR2INT* char2int,
-	CHARSET_PROC_INT2CHAR* int2char);
+int charset_detect_file(const char *path);
+int charset_detect_buf(const unsigned char *buf, int len);
+void charset_getproc(int charset, CHARSET_PROC_CHAR2INT *char2int,
+        CHARSET_PROC_INT2CHAR *int2char);
 
 #ifdef __cplusplus
 }

--- a/src/charset.h
+++ b/src/charset.h
@@ -4,8 +4,7 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-#ifndef CHARSET_H
-#define CHARSET_H
+#pragma once
 
 enum {
     CHARSET_NONE = 0,
@@ -38,5 +37,3 @@ void charset_getproc(int charset, CHARSET_PROC_CHAR2INT *char2int,
 #ifdef __cplusplus
 }
 #endif
-
-#endif // CHARSET_H

--- a/src/dbg.h
+++ b/src/dbg.h
@@ -1,23 +1,23 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
 
 #if defined(_MSC_VER) && !defined(ANSI_DEBUG)
 # include <crtdbg.h>
 #else
 # include <assert.h>
 # ifdef _DEBUG
-#  define _ASSERT(x)			assert(x)
-#  define _CRT_WARN			stderr
-#  define _RPT0(f,s)			fprintf(f,s)
-#  define _RPT1(f,s,a1)			fprintf(f,s,a1)
-#  define _RPT2(f,s,a1,a2)		fprintf(f,s,a1,a2)
-#  define _RPT3(f,s,a1,a2,a3)		fprintf(f,s,a1,a2,a3)
-#  define _RPT4(f,s,a1,a2,a3,a4)	fprintf(f,s,a1,a2,a3,a4)
+#  define _ASSERT(x)                  assert(x)
+#  define _CRT_WARN                   stderr
+#  define _RPT0(f, s)                 fprintf(f, s)
+#  define _RPT1(f, s, a1)             fprintf(f, s, a1)
+#  define _RPT2(f, s, a1, a2)         fprintf(f, s, a1, a2)
+#  define _RPT3(f, s, a1, a2, a3)     fprintf(f, s, a1, a2, a3)
+#  define _RPT4(f, s, a1, a2, a3, a4) fprintf(f, s, a1, a2, a3, a4)
 # else
 #  define _ASSERT(x)
-#  define _RPT0(f,s)
-#  define _RPT1(f,s,a1)
-#  define _RPT2(f,s,a1,a2)
-#  define _RPT3(f,s,a1,a2,a3)
-#  define _RPT4(f,s,a1,a2,a3,a4)
+#  define _RPT0(f, s)
+#  define _RPT1(f, s, a1)
+#  define _RPT2(f, s, a1, a2)
+#  define _RPT3(f, s, a1, a2, a3)
+#  define _RPT4(f, s, a1, a2, a3, a4)
 # endif
 #endif

--- a/src/filename.c
+++ b/src/filename.c
@@ -1,13 +1,14 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // filename.c - Operate filename.
 //
 // Written by:  Muraoka Taro  <koron.kaoriya@gmail.com>
 
-#include <string.h>
 #include <limits.h>
+#include <string.h>
 
-    static int
-my_strlen(const char* s)
+static int
+my_strlen(const char *s)
 {
     size_t len;
 
@@ -17,7 +18,7 @@ my_strlen(const char* s)
 
 // Cut out base string of filename from filepath.  If base is NULL, then
 // return length that require for store base name.
-    int
+int
 filename_base(char *base, const char *path)
 {
     int i;
@@ -25,128 +26,128 @@ filename_base(char *base, const char *path)
     int end;
 
     for (i = len; i >= 0; --i)
-	if (path[i] == '.')
-	    break;
+        if (path[i] == '.')
+            break;
     if (i <= 0)
-	end = len;
+        end = len;
     else
-	end = i - 1;
+        end = i - 1;
     for (i = end; i >= 0; --i)
-	if (path[i] == '\\' || path[i] == '/')
-	{
-	    ++i;
-	    break;
-	}
+        if (path[i] == '\\' || path[i] == '/')
+        {
+            ++i;
+            break;
+        }
     if (i < 0)
-	++i;
+        ++i;
     len = end - i + 1;
     if (base)
     {
-	strncpy(base, path + i, len);
-	base[len] = '\0';
+        strncpy(base, path + i, len);
+        base[len] = '\0';
     }
     return len;
 }
 
 // Cut out directroy string from filepath.  If dir is NULL, then return
 // length that require for store directory.
-    int
+int
 filename_directory(char *dir, const char *path)
 {
     int i;
 
     for (i = my_strlen(path) - 1; i >= 0; --i)
-	if (path[i] == '\\' || path[i] == '/')
-	    break;
+        if (path[i] == '\\' || path[i] == '/')
+            break;
     if (i <= 0)
     {
-	if (dir)
-	    dir[0] = '\0';
-	return 0;
+        if (dir)
+            dir[0] = '\0';
+        return 0;
     }
     if (dir)
     {
-	strncpy(dir, path, i + 1);
-	dir[i] = '\0';
+        strncpy(dir, path, i + 1);
+        dir[i] = '\0';
     }
     return i;
 }
 
 // Cut out extension of filename or filepath. If ext is NULL, then return
 // length that require for store extension.
-    int
+int
 filename_extension(char *ext, const char *path)
 {
     int i;
     int len = my_strlen(path);
 
     for (i = len - 1; i >= 0; --i)
-	if (path[i] == '.')
-	    break;
+        if (path[i] == '.')
+            break;
     if (i < 0 || i == len - 1)
     {
-	ext[0] = '\0';
-	return 0;
+        ext[0] = '\0';
+        return 0;
     }
     len -= ++i;
     if (ext)
-	strcpy(ext, path + i);
+        strcpy(ext, path + i);
     return len;
 }
 
 // Cut out filename string from filepath.  If name is NULL, then return
 // length that require for store directory.
-    int
+int
 filename_filename(char *name, const char *path)
 {
     int i;
     int len = my_strlen(path);
 
     for (i = len - 1; i >= 0; --i)
-	if (path[i] == '\\' || path[i] == '/')
-	    break;
+        if (path[i] == '\\' || path[i] == '/')
+            break;
     ++i;
     len -= i;
     if (name)
     {
-	strncpy(name, path + i, len);
-	name[len] = '\0';
+        strncpy(name, path + i, len);
+        name[len] = '\0';
     }
     return len;
 }
 
 // Generate file full path name.
-    int
-filename_generate(char *filepath, const char *dir, const char *base,
-	const char *ext)
+int
+filename_generate(
+        char *filepath, const char *dir, const char *base, const char *ext)
 {
     int len = 0;
 
     if (filepath)
-	filepath[0] = '\0';
+        filepath[0] = '\0';
     if (dir)
     {
-	if (filepath)
-	{
-	    strcat(filepath, dir);
-	    strcat(filepath, "/");
-	}
-	len += my_strlen(dir) + 1;
+        if (filepath)
+        {
+            strcat(filepath, dir);
+            strcat(filepath, "/");
+        }
+        len += my_strlen(dir) + 1;
     }
     if (base)
     {
-	if (filepath)
-	    strcat(filepath, base);
-	len += my_strlen(base);
+        if (filepath)
+            strcat(filepath, base);
+        len += my_strlen(base);
     }
     if (ext)
     {
-	if (filepath)
-	{
-	    strcat(filepath, ".");
-	    strcat(filepath, ext);
-	}
-	len += 1 + my_strlen(ext);
+        if (filepath)
+        {
+            strcat(filepath, ".");
+            strcat(filepath, ext);
+        }
+        len += 1 + my_strlen(ext);
     }
     return len;
 }

--- a/src/filename.h
+++ b/src/filename.h
@@ -4,8 +4,7 @@
 //
 // Written by:  Muraoka Taro  <koron.kaoriya@gmail.com>
 
-#ifndef FILENAME_H
-#define FILENAME_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,5 +20,3 @@ int filename_generate(
 #ifdef __cplusplus
 }
 #endif
-
-#endif // FILENAME_H

--- a/src/filename.h
+++ b/src/filename.h
@@ -1,4 +1,5 @@
-// vi:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // filename.h - Operate filename.
 //
 // Written by:  Muraoka Taro  <koron.kaoriya@gmail.com>
@@ -14,7 +15,8 @@ int filename_base(char *base, const char *path);
 int filename_directory(char *dir, const char *path);
 int filename_extension(char *ext, const char *path);
 int filename_filename(char *name, const char *path);
-int filename_generate(char *filepath, const char *dir, const char *base, const char *ext);
+int filename_generate(
+        char *filepath, const char *dir, const char *base, const char *ext);
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // main.c - migemoライブラリテストドライバ
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -11,45 +12,45 @@
 
 #include "migemo.h"
 
-#define MIGEMO_ABOUT "cmigemo - C/Migemo Library " MIGEMO_VERSION " Driver"
+#define MIGEMO_ABOUT    "cmigemo - C/Migemo Library " MIGEMO_VERSION " Driver"
 #define MIGEMODICT_NAME "migemo-dict"
 #define MIGEMO_SUBDICT_MAX 8
 
 // main
 
-    int
-query_loop(migemo* p, int quiet)
+int
+query_loop(migemo *p, int quiet)
 {
     while (!feof(stdin))
     {
-	unsigned char buf[256], *ans;
+        unsigned char buf[256], *ans;
 
-	if (!quiet)
-	    printf("QUERY: ");
-	// gets()を使っていたがfgets()に変更
-	if (!fgets(buf, sizeof(buf), stdin))
-	{
-	    if (!quiet)
-		printf("\n");
-	    break;
-	}
-	// 改行をNUL文字に置き換える
-	if ((ans = strchr(buf, '\n')) != NULL)
-	    *ans = '\0';
+        if (!quiet)
+            printf("QUERY: ");
+        // gets()を使っていたがfgets()に変更
+        if (!fgets(buf, sizeof(buf), stdin))
+        {
+            if (!quiet)
+                printf("\n");
+            break;
+        }
+        // 改行をNUL文字に置き換える
+        if ((ans = strchr(buf, '\n')) != NULL)
+            *ans = '\0';
 
-	ans = migemo_query(p, buf);
-	if (ans)
-	    printf(quiet ? "%s\n" : "PATTERN: %s\n", ans);
-	fflush(stdout);
-	migemo_release(p, ans);
+        ans = migemo_query(p, buf);
+        if (ans)
+            printf(quiet ? "%s\n" : "PATTERN: %s\n", ans);
+        fflush(stdout);
+        migemo_release(p, ans);
     }
     return 0;
 }
 
-    static void
-help(char* prgname)
+static void
+help(char *prgname)
 {
-    printf( "\
+    printf("\
 %s \n\
 \n\
 USAGE: %s [OPTIONS]\n\
@@ -63,13 +64,13 @@ OPTIONS:\n\
   -n --nonewline	Don't use newline match.\n\
   -w --word <word>	Expand a <word> and soon exit.\n\
   -h --help		Show this message.\n\
-"
-	  , MIGEMO_ABOUT, prgname, MIGEMO_SUBDICT_MAX);
+",
+            MIGEMO_ABOUT, prgname, MIGEMO_SUBDICT_MAX);
     exit(0);
 }
 
-    static migemo*
-open_first_migemo(const char**found, const char **dicts)
+static migemo *
+open_first_migemo(const char **found, const char **dicts)
 {
     for (; dicts != NULL && *dicts != NULL; dicts++)
     {
@@ -88,32 +89,32 @@ open_first_migemo(const char**found, const char **dicts)
 
 static const char *default_dicts[] = {
 #if _WIN32
-    "./dict/cp932/" MIGEMODICT_NAME,
-    "../dict/cp932/" MIGEMODICT_NAME,
-    "./build/dict/cp932/" MIGEMODICT_NAME,
+        "./dict/cp932/" MIGEMODICT_NAME,
+        "../dict/cp932/" MIGEMODICT_NAME,
+        "./build/dict/cp932/" MIGEMODICT_NAME,
 #else
-    "./dict/utf-8/" MIGEMODICT_NAME,
-    "../dict/utf-8/" MIGEMODICT_NAME,
-    "./build/dict/utf-8/" MIGEMODICT_NAME,
+        "./dict/utf-8/" MIGEMODICT_NAME,
+        "../dict/utf-8/" MIGEMODICT_NAME,
+        "./build/dict/utf-8/" MIGEMODICT_NAME,
 #endif
-    "./dict/" MIGEMODICT_NAME,
-    "../dict/" MIGEMODICT_NAME,
-    "./build/dict/" MIGEMODICT_NAME,
+        "./dict/" MIGEMODICT_NAME,
+        "../dict/" MIGEMODICT_NAME,
+        "./build/dict/" MIGEMODICT_NAME,
 #ifdef CMIGEMO_DICTDIR
-    CMIGEMO_DICTDIR "/" MIGEMODICT_NAME,
+        CMIGEMO_DICTDIR "/" MIGEMODICT_NAME,
 #endif
-    NULL,
+        NULL,
 };
 
-    int
-main(int argc, char** argv)
+int
+main(int argc, char **argv)
 {
     int mode_vim = 0;
     int mode_emacs = 0;
     int mode_nonewline = 0;
     int mode_quiet = 0;
-    char* dict = NULL;
-    char* subdict[MIGEMO_SUBDICT_MAX];
+    char *dict = NULL;
+    char *subdict[MIGEMO_SUBDICT_MAX];
     int subdict_count = 0;
     migemo *pmigemo;
     FILE *fplog = stdout;
@@ -123,26 +124,26 @@ main(int argc, char** argv)
     memset(subdict, 0, sizeof(subdict));
     while (*++argv)
     {
-	if (0)
-	    ;
-	else if (!strcmp("--vim", *argv) || !strcmp("-v", *argv))
-	    mode_vim = 1;
-	else if (!strcmp("--emacs", *argv) || !strcmp("-e", *argv))
-	    mode_emacs = 1;
-	else if (!strcmp("--nonewline", *argv) || !strcmp("-n", *argv))
-	    mode_nonewline = 1;
-	else if (argv[1] && (!strcmp("--dict", *argv) || !strcmp("-d", *argv)))
-	    dict = *++argv;
-	else if (argv[1]
-		&& (!strcmp("--subdict", *argv) || !strcmp("-s", *argv))
-		&& subdict_count < MIGEMO_SUBDICT_MAX)
-	    subdict[subdict_count++] = *++argv;
-	else if (argv[1] && (!strcmp("--word", *argv) || !strcmp("-w", *argv)))
-	    word = *++argv;
-	else if (!strcmp("--quiet", *argv) || !strcmp("-q", *argv))
-	    mode_quiet = 1;
-	else if (!strcmp("--help", *argv) || !strcmp("-h", *argv))
-	    help(prgname);
+        if (0)
+            ;
+        else if (!strcmp("--vim", *argv) || !strcmp("-v", *argv))
+            mode_vim = 1;
+        else if (!strcmp("--emacs", *argv) || !strcmp("-e", *argv))
+            mode_emacs = 1;
+        else if (!strcmp("--nonewline", *argv) || !strcmp("-n", *argv))
+            mode_nonewline = 1;
+        else if (argv[1] && (!strcmp("--dict", *argv) || !strcmp("-d", *argv)))
+            dict = *++argv;
+        else if (argv[1]
+                 && (!strcmp("--subdict", *argv) || !strcmp("-s", *argv))
+                 && subdict_count < MIGEMO_SUBDICT_MAX)
+            subdict[subdict_count++] = *++argv;
+        else if (argv[1] && (!strcmp("--word", *argv) || !strcmp("-w", *argv)))
+            word = *++argv;
+        else if (!strcmp("--quiet", *argv) || !strcmp("-q", *argv))
+            mode_quiet = 1;
+        else if (!strcmp("--help", *argv) || !strcmp("-h", *argv))
+            help(prgname);
     }
 
 #ifdef _PROFILE
@@ -155,88 +156,89 @@ main(int argc, char** argv)
         const char *found = NULL;
         pmigemo = open_first_migemo(&found, default_dicts);
         if (!word && !mode_quiet)
-	    fprintf(fplog, "migemo_open(\"%s\")=%p\n", found ? found : "(N/A)", pmigemo);
+            fprintf(fplog, "migemo_open(\"%s\")=%p\n", found ? found : "(N/A)",
+                    pmigemo);
     }
     else
     {
-	pmigemo = migemo_open(dict);
-	if (!word && !mode_quiet)
-	    fprintf(fplog, "migemo_open(\"%s\")=%p\n", dict, pmigemo);
+        pmigemo = migemo_open(dict);
+        if (!word && !mode_quiet)
+            fprintf(fplog, "migemo_open(\"%s\")=%p\n", dict, pmigemo);
     }
     // サブ辞書を読み込む
     if (subdict_count > 0)
     {
-	int i;
+        int i;
 
-	for (i = 0; i < subdict_count; ++i)
-	{
-	    int result;
+        for (i = 0; i < subdict_count; ++i)
+        {
+            int result;
 
-	    if (subdict[i] == NULL || subdict[i][0] == '\0')
-		continue;
-	    result = migemo_load(pmigemo, MIGEMO_DICTID_MIGEMO, subdict[i]);
-	    if (!word && !mode_quiet)
-		fprintf(fplog, "migemo_load(%p, %d, \"%s\")=%d\n",
-			pmigemo, MIGEMO_DICTID_MIGEMO, subdict[i], result);
-	}
+            if (subdict[i] == NULL || subdict[i][0] == '\0')
+                continue;
+            result = migemo_load(pmigemo, MIGEMO_DICTID_MIGEMO, subdict[i]);
+            if (!word && !mode_quiet)
+                fprintf(fplog, "migemo_load(%p, %d, \"%s\")=%d\n", pmigemo,
+                        MIGEMO_DICTID_MIGEMO, subdict[i], result);
+        }
     }
 
     if (!pmigemo)
-	return 1;
+        return 1;
     else
     {
-	if (mode_vim)
-	{
-	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_OR, "\\|");
-	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_IN, "\\%(");
-	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
-	    if (!mode_nonewline)
-		migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "\\_s*");
-	}
-	else if (mode_emacs)
-	{
-	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_OR, "\\|");
-	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_IN, "\\(");
-	    migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
-	    if (!mode_nonewline)
-		migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
-	}
+        if (mode_vim)
+        {
+            migemo_set_operator(pmigemo, MIGEMO_OPINDEX_OR, "\\|");
+            migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_IN, "\\%(");
+            migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
+            if (!mode_nonewline)
+                migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "\\_s*");
+        }
+        else if (mode_emacs)
+        {
+            migemo_set_operator(pmigemo, MIGEMO_OPINDEX_OR, "\\|");
+            migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_IN, "\\(");
+            migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
+            if (!mode_nonewline)
+                migemo_set_operator(pmigemo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
+        }
 #ifndef _PROFILE
-	if (word)
-	{
-	    unsigned char *ans;
+        if (word)
+        {
+            unsigned char *ans;
 
-	    ans = migemo_query(pmigemo, word);
-	    if (ans)
-		fprintf(fplog, mode_vim ? "%s" : "%s\n", ans);
-	    migemo_release(pmigemo, ans);
-	}
-	else
-	{
-	    if (!mode_quiet)
-		printf("clock()=%f\n", (float)clock() / CLOCKS_PER_SEC);
-	    query_loop(pmigemo, mode_quiet);
-	}
+            ans = migemo_query(pmigemo, word);
+            if (ans)
+                fprintf(fplog, mode_vim ? "%s" : "%s\n", ans);
+            migemo_release(pmigemo, ans);
+        }
+        else
+        {
+            if (!mode_quiet)
+                printf("clock()=%f\n", (float)clock() / CLOCKS_PER_SEC);
+            query_loop(pmigemo, mode_quiet);
+        }
 #else
-	// プロファイル用
-	{
-	    unsigned char *ans;
+        // プロファイル用
+        {
+            unsigned char *ans;
 
-	    ans = migemo_query(pmigemo, "a");
-	    if (ans)
-		fprintf(fplog, "  [%s]\n", ans);
-	    migemo_release(pmigemo, ans);
+            ans = migemo_query(pmigemo, "a");
+            if (ans)
+                fprintf(fplog, "  [%s]\n", ans);
+            migemo_release(pmigemo, ans);
 
-	    ans = migemo_query(pmigemo, "k");
-	    if (ans)
-		fprintf(fplog, "  [%s]\n", ans);
-	    migemo_release(pmigemo, ans);
-	}
+            ans = migemo_query(pmigemo, "k");
+            if (ans)
+                fprintf(fplog, "  [%s]\n", ans);
+            migemo_release(pmigemo, ans);
+        }
 #endif
-	migemo_close(pmigemo);
+        migemo_close(pmigemo);
     }
 
     if (fplog != stdout)
-	fclose(fplog);
+        fclose(fplog);
     return 0;
 }

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -1,28 +1,30 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // migemo.c -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include <ctype.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <limits.h>
 
+#include "charset.h"
+#include "filename.h"
+#include "migemo.h"
+#include "mnode.h"
+#include "romaji.h"
+#include "rxgen.h"
 #include "wordbuf.h"
 #include "wordlist.h"
-#include "mnode.h"
-#include "rxgen.h"
-#include "romaji.h"
-#include "filename.h"
-#include "charset.h"
-#include "migemo.h"
 
-#define DICT_MIGEMO "migemo-dict"
+#define DICT_MIGEMO    "migemo-dict"
 #define DICT_ROMA2HIRA "roma2hira.dat"
 #define DICT_HIRA2KATA "hira2kata.dat"
-#define DICT_HAN2ZEN "han2zen.dat"
-#define DICT_ZEN2HAN "zen2han.dat"
+#define DICT_HAN2ZEN   "han2zen.dat"
+#define DICT_ZEN2HAN   "zen2han.dat"
+
 #define BUFLEN_DETECT_CHARSET 4096
 
 #ifdef __BORLANDC__
@@ -31,7 +33,7 @@
 # define EXPORTS
 #endif
 
-typedef int (*MIGEMO_PROC_ADDWORD)(void* data, unsigned char* word);
+typedef int (*MIGEMO_PROC_ADDWORD)(void *data, unsigned char *word);
 
 // migemoオブジェクト
 struct _migemo
@@ -39,19 +41,19 @@ struct _migemo
     int enable;
     mtree_p mtree;
     int charset;
-    romaji* roma2hira;
-    romaji* hira2kata;
-    romaji* han2zen;
-    romaji* zen2han;
-    rxgen* rx;
+    romaji *roma2hira;
+    romaji *hira2kata;
+    romaji *han2zen;
+    romaji *zen2han;
+    rxgen *rx;
     MIGEMO_PROC_ADDWORD addword;
     CHARSET_PROC_CHAR2INT char2int;
 };
 
 static const unsigned char VOWEL_CHARS[] = "aiueo";
 
-    static int
-my_strlen(const char* s)
+static int
+my_strlen(const char *s)
 {
     size_t len;
 
@@ -59,41 +61,41 @@ my_strlen(const char* s)
     return len <= INT_MAX ? (int)len : INT_MAX;
 }
 
-    static mtree_p
-load_mtree_dictionary(mtree_p mtree, const char* dict_file)
+static mtree_p
+load_mtree_dictionary(mtree_p mtree, const char *dict_file)
 {
     FILE *fp;
 
     if ((fp = fopen(dict_file, "rt")) == NULL)
-	return NULL;			// Can't find file
+        return NULL; // Can't find file
     mtree = mnode_load(mtree, fp);
     fclose(fp);
     return mtree;
 }
 
-    static mtree_p
-load_mtree_dictionary2(migemo* obj, const char* dict_file)
+static mtree_p
+load_mtree_dictionary2(migemo *obj, const char *dict_file)
 {
     if (obj->charset == CHARSET_NONE)
     {
-	// 辞書の文字セットにあわせて正規表現生成時の関数を変更する
-	CHARSET_PROC_CHAR2INT char2int = NULL;
-	CHARSET_PROC_INT2CHAR int2char = NULL;
-	obj->charset = charset_detect_file(dict_file);
-	charset_getproc(obj->charset, &char2int, &int2char);
-	if (char2int)
-	{
-	    migemo_setproc_char2int(obj, (MIGEMO_PROC_CHAR2INT)char2int);
-	    obj->char2int = char2int;
-	}
-	if (int2char)
-	    migemo_setproc_int2char(obj, (MIGEMO_PROC_INT2CHAR)int2char);
+        // 辞書の文字セットにあわせて正規表現生成時の関数を変更する
+        CHARSET_PROC_CHAR2INT char2int = NULL;
+        CHARSET_PROC_INT2CHAR int2char = NULL;
+        obj->charset = charset_detect_file(dict_file);
+        charset_getproc(obj->charset, &char2int, &int2char);
+        if (char2int)
+        {
+            migemo_setproc_char2int(obj, (MIGEMO_PROC_CHAR2INT)char2int);
+            obj->char2int = char2int;
+        }
+        if (int2char)
+            migemo_setproc_int2char(obj, (MIGEMO_PROC_INT2CHAR)int2char);
     }
     return load_mtree_dictionary(obj->mtree, dict_file);
 }
 
-    static void
-dircat(char* buf, const char* dir, const char* file)
+static void
+dircat(char *buf, const char *dir, const char *file)
 {
     strcpy(buf, dir);
     strcat(buf, "/");
@@ -126,53 +128,53 @@ dircat(char* buf, const char* dir, const char* file)
 /// @param obj Migemoオブジェクト
 /// @param dict_id 辞書ファイルの種類
 /// @param dict_file 辞書ファイルのパス
-    EXPORTS int MIGEMO_CALLTYPE
-migemo_load(migemo* obj, int dict_id, const char* dict_file)
+EXPORTS int MIGEMO_CALLTYPE
+migemo_load(migemo *obj, int dict_id, const char *dict_file)
 {
     if (!obj && dict_file)
-	return MIGEMO_DICTID_INVALID;
+        return MIGEMO_DICTID_INVALID;
 
     if (dict_id == MIGEMO_DICTID_MIGEMO)
     {
-	// migemo辞書読み込み
-	mtree_p mtree;
+        // migemo辞書読み込み
+        mtree_p mtree;
 
-	if ((mtree = load_mtree_dictionary2(obj, dict_file)) == NULL)
-	    return MIGEMO_DICTID_INVALID;
-	obj->mtree = mtree;
-	obj->enable = 1;
-	return dict_id;			// Loaded successfully
+        if ((mtree = load_mtree_dictionary2(obj, dict_file)) == NULL)
+            return MIGEMO_DICTID_INVALID;
+        obj->mtree = mtree;
+        obj->enable = 1;
+        return dict_id; // Loaded successfully
     }
     else
     {
-	romaji *dict;
+        romaji *dict;
 
-	switch (dict_id)
-	{
-	    case MIGEMO_DICTID_ROMA2HIRA:
-		// ローマ字辞書読み込み
-		dict = obj->roma2hira;
-		break;
-	    case MIGEMO_DICTID_HIRA2KATA:
-		// カタカナ辞書読み込み
-		dict = obj->hira2kata;
-		break;
-	    case MIGEMO_DICTID_HAN2ZEN:
-		// 半角→全角辞書読み込み
-		dict = obj->han2zen;
-		break;
-	    case MIGEMO_DICTID_ZEN2HAN:
-		// 半角→全角辞書読み込み
-		dict = obj->zen2han;
-		break;
-	    default:
-		dict = NULL;
-		break;
-	}
-	if (dict && romaji_load(dict, dict_file) == 0)
-	    return dict_id;
-	else
-	    return MIGEMO_DICTID_INVALID;
+        switch (dict_id)
+        {
+            case MIGEMO_DICTID_ROMA2HIRA:
+                // ローマ字辞書読み込み
+                dict = obj->roma2hira;
+                break;
+            case MIGEMO_DICTID_HIRA2KATA:
+                // カタカナ辞書読み込み
+                dict = obj->hira2kata;
+                break;
+            case MIGEMO_DICTID_HAN2ZEN:
+                // 半角→全角辞書読み込み
+                dict = obj->han2zen;
+                break;
+            case MIGEMO_DICTID_ZEN2HAN:
+                // 半角→全角辞書読み込み
+                dict = obj->zen2han;
+                break;
+            default:
+                dict = NULL;
+                break;
+        }
+        if (dict && romaji_load(dict, dict_file) == 0)
+            return dict_id;
+        else
+            return MIGEMO_DICTID_INVALID;
     }
 }
 
@@ -195,27 +197,27 @@ migemo_load(migemo* obj, int dict_id, const char* dict_file)
 /// 込みができる。
 /// @param dict migemo-dict辞書のパス。NULLの時は辞書を読み込まない。
 /// @returns 作成されたMigemoオブジェクト
-    EXPORTS migemo* MIGEMO_CALLTYPE
-migemo_open(const char* dict)
+EXPORTS migemo *MIGEMO_CALLTYPE
+migemo_open(const char *dict)
 {
     migemo *obj;
 
     // migemoオブジェクトと各メンバを構築
-    if (!(obj = (migemo*)calloc(1, sizeof(migemo))))
-	return obj;
+    if (!(obj = (migemo *)calloc(1, sizeof(migemo))))
+        return obj;
     obj->enable = 0;
     obj->mtree = mnode_open(NULL);
     obj->charset = CHARSET_NONE;
     obj->rx = rxgen_open();
-    obj->roma2hira =	romaji_open();
-    obj->hira2kata =	romaji_open();
-    obj->han2zen =	romaji_open();
-    obj->zen2han =	romaji_open();
+    obj->roma2hira = romaji_open();
+    obj->hira2kata = romaji_open();
+    obj->han2zen = romaji_open();
+    obj->zen2han = romaji_open();
     if (!obj->rx || !obj->roma2hira || !obj->hira2kata || !obj->han2zen
-	    || !obj->zen2han)
+            || !obj->zen2han)
     {
-	migemo_close(obj);
-	return obj = NULL;
+        migemo_close(obj);
+        return obj = NULL;
     }
 
     // デフォルトmigemo辞書が指定されていたらローマ字とカタカナ辞書も探す
@@ -224,106 +226,106 @@ migemo_open(const char* dict)
 #ifndef _MAX_PATH
 # define _MAX_PATH 1024 // いい加減な数値
 #endif
-	char dir[_MAX_PATH];
-	char roma_dict[_MAX_PATH];
-	char kata_dict[_MAX_PATH];
-	char h2z_dict[_MAX_PATH];
-	char z2h_dict[_MAX_PATH];
-	const char *tmp;
-	mtree_p mtree;
+        char dir[_MAX_PATH];
+        char roma_dict[_MAX_PATH];
+        char kata_dict[_MAX_PATH];
+        char h2z_dict[_MAX_PATH];
+        char z2h_dict[_MAX_PATH];
+        const char *tmp;
+        mtree_p mtree;
 
-	filename_directory(dir, dict);
-	tmp = strlen(dir) ? dir : ".";
-	dircat(roma_dict, tmp, DICT_ROMA2HIRA);
-	dircat(kata_dict, tmp, DICT_HIRA2KATA);
-	dircat(h2z_dict,  tmp, DICT_HAN2ZEN);
-	dircat(z2h_dict,  tmp, DICT_ZEN2HAN);
+        filename_directory(dir, dict);
+        tmp = strlen(dir) ? dir : ".";
+        dircat(roma_dict, tmp, DICT_ROMA2HIRA);
+        dircat(kata_dict, tmp, DICT_HIRA2KATA);
+        dircat(h2z_dict, tmp, DICT_HAN2ZEN);
+        dircat(z2h_dict, tmp, DICT_ZEN2HAN);
 
-	mtree = load_mtree_dictionary2(obj, dict);
-	if (mtree)
-	{
-	    obj->mtree = mtree;
-	    obj->enable = 1;
-	    romaji_load(obj->roma2hira, roma_dict);
-	    romaji_load(obj->hira2kata, kata_dict);
-	    romaji_load(obj->han2zen, h2z_dict);
-	    romaji_load(obj->zen2han, z2h_dict);
-	}
+        mtree = load_mtree_dictionary2(obj, dict);
+        if (mtree)
+        {
+            obj->mtree = mtree;
+            obj->enable = 1;
+            romaji_load(obj->roma2hira, roma_dict);
+            romaji_load(obj->hira2kata, kata_dict);
+            romaji_load(obj->han2zen, h2z_dict);
+            romaji_load(obj->zen2han, z2h_dict);
+        }
     }
     return obj;
 }
 
 /// Migemoオブジェクトを破棄し、使用していたリソースを解放する。
 /// @param obj 破棄するMigemoオブジェクト
-    EXPORTS void MIGEMO_CALLTYPE
-migemo_close(migemo* obj)
+EXPORTS void MIGEMO_CALLTYPE
+migemo_close(migemo *obj)
 {
     if (obj)
     {
-	if (obj->zen2han)
-	    romaji_close(obj->zen2han);
-	if (obj->han2zen)
-	    romaji_close(obj->han2zen);
-	if (obj->hira2kata)
-	    romaji_close(obj->hira2kata);
-	if (obj->roma2hira)
-	    romaji_close(obj->roma2hira);
-	if (obj->rx)
-	    rxgen_close(obj->rx);
-	if (obj->mtree)
-	    mnode_close(obj->mtree);
-	free(obj);
+        if (obj->zen2han)
+            romaji_close(obj->zen2han);
+        if (obj->han2zen)
+            romaji_close(obj->han2zen);
+        if (obj->hira2kata)
+            romaji_close(obj->hira2kata);
+        if (obj->roma2hira)
+            romaji_close(obj->roma2hira);
+        if (obj->rx)
+            rxgen_close(obj->rx);
+        if (obj->mtree)
+            mnode_close(obj->mtree);
+        free(obj);
     }
 }
 
 // query version 2
 
 // mnodeの持つ単語リストを正規表現生成エンジンに入力する。
-    static void
-migemo_query_proc(mnode* p, void* data)
+static void
+migemo_query_proc(mnode *p, void *data)
 {
-    migemo *object = (migemo*)data;
+    migemo *object = (migemo *)data;
     wordlist_p list = p->list;
 
     for (; list; list = list->next)
-	object->addword(object, list->ptr);
+        object->addword(object, list->ptr);
 }
 
 // バッファを用意してmnodeに再帰で書き込ませる
-    static void
-add_mnode_query(migemo* object, unsigned char* query)
+static void
+add_mnode_query(migemo *object, unsigned char *query)
 {
     mnode *pnode;
 
     if ((pnode = mnode_query(object->mtree, query)) != NULL)
-	mnode_traverse(pnode, migemo_query_proc, object);
+        mnode_traverse(pnode, migemo_query_proc, object);
 }
 
 /// 入力をローマから仮名に変換して検索キーに加える。
-    static int
-add_roma(migemo* object, unsigned char* query)
+static int
+add_roma(migemo *object, unsigned char *query)
 {
     unsigned char *stop, *hira, *kata, *han;
 
     hira = romaji_convert(object->roma2hira, query, &stop);
     if (!stop)
     {
-	object->addword(object, hira);
-	// 平仮名による辞書引き
-	add_mnode_query(object, hira);
-	// 片仮名文字列を生成し候補に加える
-	kata = romaji_convert2(object->hira2kata, hira, NULL, 0);
-	object->addword(object, kata);
-	// TODO: 半角カナを生成し候補に加える
+        object->addword(object, hira);
+        // 平仮名による辞書引き
+        add_mnode_query(object, hira);
+        // 片仮名文字列を生成し候補に加える
+        kata = romaji_convert2(object->hira2kata, hira, NULL, 0);
+        object->addword(object, kata);
+        // TODO: 半角カナを生成し候補に加える
 #if 1
-	han = romaji_convert2(object->zen2han, kata, NULL, 0);
-	object->addword(object, han);
-	//printf("kata=%s\nhan=%s\n", kata, han);
-	romaji_release(object->zen2han, han);
+        han = romaji_convert2(object->zen2han, kata, NULL, 0);
+        object->addword(object, han);
+        // printf("kata=%s\nhan=%s\n", kata, han);
+        romaji_release(object->zen2han, han);
 #endif
-	// カタカナによる辞書引き
-	add_mnode_query(object, kata);
-	romaji_release(object->hira2kata, kata); // カタカナ解放
+        // カタカナによる辞書引き
+        add_mnode_query(object, kata);
+        romaji_release(object->hira2kata, kata); // カタカナ解放
     }
     romaji_release(object->roma2hira, hira); // 平仮名解放
 
@@ -331,57 +333,57 @@ add_roma(migemo* object, unsigned char* query)
 }
 
 /// ローマ字の末尾に母音を付け加えて、各々を検索キーに加える。
-    static void
-add_dubious_vowels(migemo* object, unsigned char* buf, int index)
+static void
+add_dubious_vowels(migemo *object, unsigned char *buf, int index)
 {
-    const unsigned char* ptr;
+    const unsigned char *ptr;
     for (ptr = VOWEL_CHARS; *ptr; ++ptr)
     {
-	buf[index] = *ptr;
-	add_roma(object, buf);
+        buf[index] = *ptr;
+        add_roma(object, buf);
     }
 }
 
 // ローマ字変換が不完全だった時に、[aiueo]および"xn"と"xtu"を補って変換して
 // みる。
-    static void
-add_dubious_roma(migemo* object, rxgen* rx, unsigned char* query)
+static void
+add_dubious_roma(migemo *object, rxgen *rx, unsigned char *query)
 {
     int max;
     int len;
     char *buf;
 
     if (!(len = my_strlen(query)))
-	return;
+        return;
     // ローマ字の末尾のアレンジのためのバッファを確保する。
     //	    内訳: オリジナルの長さ、NUL、吃音(xtu)、補足母音([aieuo])
     max = len + 1 + 3 + 1;
     buf = malloc(max);
     if (buf == NULL)
-	return;
+        return;
     memcpy(buf, query, len);
     memset(&buf[len], 0, max - len);
 
     if (!strchr(VOWEL_CHARS, buf[len - 1]))
     {
-	add_dubious_vowels(object, buf, len);
-	// 未確定単語の長さが2未満か、未確定文字の直前が母音ならば…
-	if (len < 2 || strchr(VOWEL_CHARS, buf[len - 2]))
-	{
-	    if (buf[len - 1] == 'n')
-	    {
-		// 「ん」を補ってみる
-		memcpy(&buf[len - 1], "xn", 2);
-		add_roma(object, buf);
-	    }
-	    else
-	    {
-		// 「っ{元の子音}{母音}」を補ってみる
-		buf[len + 2] = buf[len - 1];
-		memcpy(&buf[len - 1], "xtu", 3);
-		add_dubious_vowels(object, buf, len + 3);
-	    }
-	}
+        add_dubious_vowels(object, buf, len);
+        // 未確定単語の長さが2未満か、未確定文字の直前が母音ならば…
+        if (len < 2 || strchr(VOWEL_CHARS, buf[len - 2]))
+        {
+            if (buf[len - 1] == 'n')
+            {
+                // 「ん」を補ってみる
+                memcpy(&buf[len - 1], "xn", 2);
+                add_roma(object, buf);
+            }
+            else
+            {
+                // 「っ{元の子音}{母音}」を補ってみる
+                buf[len + 2] = buf[len - 1];
+                memcpy(&buf[len - 1], "xtu", 3);
+                add_dubious_vowels(object, buf, len + 3);
+            }
+        }
     }
 
     free(buf);
@@ -389,8 +391,8 @@ add_dubious_roma(migemo* object, rxgen* rx, unsigned char* query)
 
 // queryを文節に分解する。文節の切れ目は通常アルファベットの大文字。文節が複
 // 数文字の大文字で始まった文節は非大文字を区切りとする。
-    static wordlist_p
-parse_query(migemo* object, const unsigned char* query)
+static wordlist_p
+parse_query(migemo *object, const unsigned char *query)
 {
     const unsigned char *curr = query;
     const unsigned char *start = NULL;
@@ -398,43 +400,43 @@ parse_query(migemo* object, const unsigned char* query)
 
     while (1)
     {
-	int len, upper;
+        int len, upper;
         int sum = 0;
 
-	if (!object->char2int || (len = object->char2int(curr, NULL)) < 1)
-	    len = 1;
-	start = curr;
-	upper = (len == 1 && isupper(*curr) && isupper(curr[1]));
-	curr += len;
+        if (!object->char2int || (len = object->char2int(curr, NULL)) < 1)
+            len = 1;
+        start = curr;
+        upper = (len == 1 && isupper(*curr) && isupper(curr[1]));
+        curr += len;
         sum += len;
-	while (1)
-	{
-	    if (!object->char2int || (len = object->char2int(curr, NULL)) < 1)
-		len = 1;
-	    if (*curr == '\0' || (len == 1 && (isupper(*curr) != 0) != upper))
-		break;
-	    curr += len;
+        while (1)
+        {
+            if (!object->char2int || (len = object->char2int(curr, NULL)) < 1)
+                len = 1;
+            if (*curr == '\0' || (len == 1 && (isupper(*curr) != 0) != upper))
+                break;
+            curr += len;
             sum += len;
-	}
-	// 文節を登録する
-	if (start && start < curr)
-	{
-	    *pp = wordlist_open_len(start, sum);
-	    pp = &(*pp)->next;
-	}
-	if (*curr == '\0')
-	    break;
+        }
+        // 文節を登録する
+        if (start && start < curr)
+        {
+            *pp = wordlist_open_len(start, sum);
+            pp = &(*pp)->next;
+        }
+        if (*curr == '\0')
+            break;
     }
     return querylist;
 }
 
 // 1つの単語をmigemo変換。引数のチェックは行なわない。
-    static int
-query_a_word(migemo* object, unsigned char* query)
+static int
+query_a_word(migemo *object, unsigned char *query)
 {
-    unsigned char* zen;
-    unsigned char* han;
-    unsigned char* lower;
+    unsigned char *zen;
+    unsigned char *han;
+    unsigned char *lower;
     int len = my_strlen(query);
 
     // query自信はもちろん候補に加える
@@ -442,55 +444,55 @@ query_a_word(migemo* object, unsigned char* query)
     // queryそのものでの辞書引き
     lower = malloc(len + 1);
     if (!lower)
-	add_mnode_query(object, query);
+        add_mnode_query(object, query);
     else
     {
-	int i = 0, step;
+        int i = 0, step;
 
-	// MBを考慮した大文字→小文字変換
-	while (i <= len)
-	{
-	    if (!object->char2int
-		    || (step = object->char2int(&query[i], NULL)) < 1)
-		step = 1;
-	    if (step == 1 && isupper(query[i]))
-		lower[i] = (unsigned char)tolower(query[i]);
-	    else
-		memcpy(&lower[i], &query[i], step);
-	    i += step;
-	}
-	add_mnode_query(object, lower);
-	free(lower);
+        // MBを考慮した大文字→小文字変換
+        while (i <= len)
+        {
+            if (!object->char2int
+                    || (step = object->char2int(&query[i], NULL)) < 1)
+                step = 1;
+            if (step == 1 && isupper(query[i]))
+                lower[i] = (unsigned char)tolower(query[i]);
+            else
+                memcpy(&lower[i], &query[i], step);
+            i += step;
+        }
+        add_mnode_query(object, lower);
+        free(lower);
     }
 
     // queryを全角にして候補に加える
     zen = romaji_convert2(object->han2zen, query, NULL, 0);
     if (zen != NULL)
     {
-	object->addword(object, zen);
-	romaji_release(object->han2zen, zen);
+        object->addword(object, zen);
+        romaji_release(object->han2zen, zen);
     }
 
     // queryを半角にして候補に加える
     han = romaji_convert2(object->zen2han, query, NULL, 0);
     if (han != NULL)
     {
-	object->addword(object, han);
-	romaji_release(object->zen2han, han);
+        object->addword(object, han);
+        romaji_release(object->zen2han, han);
     }
 
     // 平仮名、カタカナ、及びそれによる辞書引き追加
     if (add_roma(object, query))
-	add_dubious_roma(object, object->rx, query);
+        add_dubious_roma(object, object->rx, query);
 
     return 1;
 }
 
-    static int
-addword_rxgen(migemo* object, unsigned char* word)
+static int
+addword_rxgen(migemo *object, unsigned char *word)
 {
     // 正規表現生成エンジンに追加された単語を表示する
-    //printf("addword_rxgen: %s\n", word);
+    // printf("addword_rxgen: %s\n", word);
     return rxgen_add(object->rx, word);
 }
 
@@ -500,8 +502,8 @@ addword_rxgen(migemo* object, unsigned char* word)
 /// @param object Migemoオブジェクト
 /// @param query 問い合わせ文字列
 /// @returns 正規表現文字列。#migemo_release() で解放する必要有り。
-    EXPORTS unsigned char* MIGEMO_CALLTYPE
-migemo_query(migemo* object, const unsigned char* query)
+EXPORTS unsigned char *MIGEMO_CALLTYPE
+migemo_query(migemo *object, const unsigned char *query)
 {
     unsigned char *retval = NULL;
     wordlist_p querylist = NULL;
@@ -509,41 +511,41 @@ migemo_query(migemo* object, const unsigned char* query)
 
     if (object && object->rx && query)
     {
-	wordlist_p p;
+        wordlist_p p;
 
-	querylist = parse_query(object, query);
-	if (querylist == NULL)
-	    goto MIGEMO_QUERY_END; // 空queryのためエラー
-	outbuf = wordbuf_open();
-	if (outbuf == NULL)
-	    goto MIGEMO_QUERY_END; // 出力用のメモリ領域不足のためエラー
+        querylist = parse_query(object, query);
+        if (querylist == NULL)
+            goto MIGEMO_QUERY_END; // 空queryのためエラー
+        outbuf = wordbuf_open();
+        if (outbuf == NULL)
+            goto MIGEMO_QUERY_END; // 出力用のメモリ領域不足のためエラー
 
-	// 単語群をrxgenオブジェクトに入力し正規表現を得る
-	object->addword = (MIGEMO_PROC_ADDWORD)addword_rxgen;
-	rxgen_reset(object->rx);
-	for (p = querylist; p; p = p->next)
-	{
-	    unsigned char* answer;
+        // 単語群をrxgenオブジェクトに入力し正規表現を得る
+        object->addword = (MIGEMO_PROC_ADDWORD)addword_rxgen;
+        rxgen_reset(object->rx);
+        for (p = querylist; p; p = p->next)
+        {
+            unsigned char *answer;
 
-	    //printf("query=%s\n", p->ptr);
-	    query_a_word(object, p->ptr);
-	    // 検索パターン(正規表現)生成
-	    answer = rxgen_generate(object->rx);
-	    rxgen_reset(object->rx);
-	    wordbuf_cat(outbuf, answer);
-	    rxgen_release(object->rx, answer);
-	}
+            // printf("query=%s\n", p->ptr);
+            query_a_word(object, p->ptr);
+            // 検索パターン(正規表現)生成
+            answer = rxgen_generate(object->rx);
+            rxgen_reset(object->rx);
+            wordbuf_cat(outbuf, answer);
+            rxgen_release(object->rx, answer);
+        }
     }
 
 MIGEMO_QUERY_END:
     if (outbuf)
     {
-	retval = outbuf->buf;
-	outbuf->buf = NULL;
-	wordbuf_close(outbuf);
+        retval = outbuf->buf;
+        outbuf->buf = NULL;
+        wordbuf_close(outbuf);
     }
     if (querylist)
-	wordlist_close(querylist);
+        wordlist_close(querylist);
 
     return retval;
 }
@@ -551,8 +553,8 @@ MIGEMO_QUERY_END:
 /// 使い終わったmigemo_query()関数で得られた正規表現を解放する。
 /// @param p Migemoオブジェクト
 /// @param string 正規表現文字列
-    EXPORTS void MIGEMO_CALLTYPE
-migemo_release(migemo* p, unsigned char* string)
+EXPORTS void MIGEMO_CALLTYPE
+migemo_release(migemo *p, unsigned char *string)
 {
     free(string);
 }
@@ -587,16 +589,16 @@ migemo_release(migemo* p, unsigned char* string)
 /// @param index メタ文字識別子
 /// @param op メタ文字文字列
 /// @returns 成功時0以外、失敗時0。
-    EXPORTS int MIGEMO_CALLTYPE
-migemo_set_operator(migemo* object, int index, const unsigned char* op)
+EXPORTS int MIGEMO_CALLTYPE
+migemo_set_operator(migemo *object, int index, const unsigned char *op)
 {
     if (object)
     {
-	int retval = rxgen_set_operator(object->rx, index, op);
-	return retval ? 0 : 1;
+        int retval = rxgen_set_operator(object->rx, index, op);
+        return retval ? 0 : 1;
     }
     else
-	return 0;
+        return 0;
 }
 
 /// Migemoオブジェクトが生成する正規表現に使用しているメタ文字(演算子)を取得
@@ -606,8 +608,8 @@ migemo_set_operator(migemo* object, int index, const unsigned char* op)
 /// @param object Migemoオブジェクト
 /// @param index メタ文字識別子
 /// @returns 現在のメタ文字文字列
-    EXPORTS const unsigned char* MIGEMO_CALLTYPE
-migemo_get_operator(migemo* object, int index)
+EXPORTS const unsigned char *MIGEMO_CALLTYPE
+migemo_get_operator(migemo *object, int index)
 {
     return object ? rxgen_get_operator(object->rx, index) : NULL;
 }
@@ -616,22 +618,22 @@ migemo_get_operator(migemo* object, int index)
 /// ついての詳細は「型リファレンス」セクションのMIGEMO_PROC_CHAR2INTを参照。
 /// @param object Migemoオブジェクト
 /// @param proc コード変換用プロシージャ
-    EXPORTS void MIGEMO_CALLTYPE
-migemo_setproc_char2int(migemo* object, MIGEMO_PROC_CHAR2INT proc)
+EXPORTS void MIGEMO_CALLTYPE
+migemo_setproc_char2int(migemo *object, MIGEMO_PROC_CHAR2INT proc)
 {
     if (object)
-	rxgen_setproc_char2int(object->rx, (RXGEN_PROC_CHAR2INT)proc);
+        rxgen_setproc_char2int(object->rx, (RXGEN_PROC_CHAR2INT)proc);
 }
 
 /// Migemoオブジェクトにコード変換用のプロシージャを設定する。プロシージャに
 /// ついての詳細は「型リファレンス」セクションのMIGEMO_PROC_INT2CHARを参照。
 /// @param object Migemoオブジェクト
 /// @param proc コード変換用プロシージャ
-    EXPORTS void MIGEMO_CALLTYPE
-migemo_setproc_int2char(migemo* object, MIGEMO_PROC_INT2CHAR proc)
+EXPORTS void MIGEMO_CALLTYPE
+migemo_setproc_int2char(migemo *object, MIGEMO_PROC_INT2CHAR proc)
 {
     if (object)
-	rxgen_setproc_int2char(object->rx, (RXGEN_PROC_INT2CHAR)proc);
+        rxgen_setproc_int2char(object->rx, (RXGEN_PROC_INT2CHAR)proc);
 }
 
 /// Migemoオブジェクトにmigemo_dictが読み込めているかをチェックする。有効な
@@ -639,18 +641,18 @@ migemo_setproc_int2char(migemo* object, MIGEMO_PROC_INT2CHAR proc)
 /// を、構築できていないときには0(FALSE)を返す。
 /// @param obj Migemoオブジェクト
 /// @returns 成功時0以外、失敗時0。
-    EXPORTS int MIGEMO_CALLTYPE
-migemo_is_enable(migemo* obj)
+EXPORTS int MIGEMO_CALLTYPE
+migemo_is_enable(migemo *obj)
 {
     return obj ? obj->enable : 0;
 }
 
 #if 1
 // 主にデバッグ用の隠し関数
-    EXPORTS void MIGEMO_CALLTYPE
-migemo_print(migemo* object)
+EXPORTS void MIGEMO_CALLTYPE
+migemo_print(migemo *object)
 {
     if (object)
-	mnode_print(object->mtree, NULL);
+        mnode_print(object->mtree, NULL);
 }
 #endif

--- a/src/migemo.h
+++ b/src/migemo.h
@@ -1,4 +1,5 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // migemo.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -15,24 +16,24 @@
 #define MIGEMO_VERSION "1.4"
 
 // for migemo_load()
-#define MIGEMO_DICTID_INVALID		0
-#define MIGEMO_DICTID_MIGEMO		1
-#define MIGEMO_DICTID_ROMA2HIRA		2
-#define MIGEMO_DICTID_HIRA2KATA		3
-#define MIGEMO_DICTID_HAN2ZEN		4
-#define MIGEMO_DICTID_ZEN2HAN		5
+#define MIGEMO_DICTID_INVALID   0
+#define MIGEMO_DICTID_MIGEMO    1
+#define MIGEMO_DICTID_ROMA2HIRA 2
+#define MIGEMO_DICTID_HIRA2KATA 3
+#define MIGEMO_DICTID_HAN2ZEN   4
+#define MIGEMO_DICTID_ZEN2HAN   5
 
 // for migemo_set_operator()/migemo_get_operator().  see: rxgen.h
-#define MIGEMO_OPINDEX_OR		0
-#define MIGEMO_OPINDEX_NEST_IN		1
-#define MIGEMO_OPINDEX_NEST_OUT		2
-#define MIGEMO_OPINDEX_SELECT_IN	3
-#define MIGEMO_OPINDEX_SELECT_OUT	4
-#define MIGEMO_OPINDEX_NEWLINE		5
+#define MIGEMO_OPINDEX_OR         0
+#define MIGEMO_OPINDEX_NEST_IN    1
+#define MIGEMO_OPINDEX_NEST_OUT   2
+#define MIGEMO_OPINDEX_SELECT_IN  3
+#define MIGEMO_OPINDEX_SELECT_OUT 4
+#define MIGEMO_OPINDEX_NEWLINE    5
 
 // see: rxgen.h
-typedef int (*MIGEMO_PROC_CHAR2INT)(const unsigned char*, unsigned int*);
-typedef int (*MIGEMO_PROC_INT2CHAR)(unsigned int, unsigned char*);
+typedef int (*MIGEMO_PROC_CHAR2INT)(const unsigned char *, unsigned int *);
+typedef int (*MIGEMO_PROC_INT2CHAR)(unsigned int, unsigned char *);
 
 /// Migemoオブジェクト。migemo_open()で作成され、migemo_closeで破棄される。
 typedef struct _migemo migemo;
@@ -41,25 +42,24 @@ typedef struct _migemo migemo;
 extern "C" {
 #endif
 
-migemo* MIGEMO_CALLTYPE	migemo_open(const char* dict);
-void MIGEMO_CALLTYPE	migemo_close(migemo* object);
-unsigned char* MIGEMO_CALLTYPE migemo_query(migemo* object,
-	const unsigned char* query);
-void MIGEMO_CALLTYPE	migemo_release(migemo* object,
-	unsigned char* string);
+migemo *MIGEMO_CALLTYPE migemo_open(const char *dict);
+void MIGEMO_CALLTYPE migemo_close(migemo *object);
+unsigned char *MIGEMO_CALLTYPE migemo_query(
+        migemo *object, const unsigned char *query);
+void MIGEMO_CALLTYPE migemo_release(migemo *object, unsigned char *string);
 
-int MIGEMO_CALLTYPE	migemo_set_operator(migemo* object, int index,
-	const unsigned char* op);
-const unsigned char* MIGEMO_CALLTYPE migemo_get_operator(migemo* object,
-	int index);
-void MIGEMO_CALLTYPE	migemo_setproc_char2int(migemo* object,
-	MIGEMO_PROC_CHAR2INT proc);
-void MIGEMO_CALLTYPE	migemo_setproc_int2char(migemo* object,
-	MIGEMO_PROC_INT2CHAR proc);
+int MIGEMO_CALLTYPE migemo_set_operator(
+        migemo *object, int index, const unsigned char *op);
+const unsigned char *MIGEMO_CALLTYPE migemo_get_operator(
+        migemo *object, int index);
+void MIGEMO_CALLTYPE migemo_setproc_char2int(
+        migemo *object, MIGEMO_PROC_CHAR2INT proc);
+void MIGEMO_CALLTYPE migemo_setproc_int2char(
+        migemo *object, MIGEMO_PROC_INT2CHAR proc);
 
-int MIGEMO_CALLTYPE	migemo_load(migemo* obj, int dict_id,
-	const char* dict_file);
-int MIGEMO_CALLTYPE	migemo_is_enable(migemo* obj);
+int MIGEMO_CALLTYPE migemo_load(
+        migemo *obj, int dict_id, const char *dict_file);
+int MIGEMO_CALLTYPE migemo_is_enable(migemo *obj);
 
 #ifdef __cplusplus
 }

--- a/src/migemo.h
+++ b/src/migemo.h
@@ -4,8 +4,7 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-#ifndef MIGEMO_H
-#define MIGEMO_H
+#pragma once
 
 #if defined(_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN32__)
 # define MIGEMO_CALLTYPE __stdcall
@@ -64,5 +63,3 @@ int MIGEMO_CALLTYPE migemo_is_enable(migemo *obj);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // MIGEMO_H

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -1,25 +1,26 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // mnode.c - mnode interfaces.
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "dbg.h"
-#include "wordlist.h"
-#include "wordbuf.h"
 #include "mnode.h"
+#include "wordbuf.h"
+#include "wordlist.h"
 
 #define MTREE_MNODE_N 1024
 struct _mtree_t
 {
-    mtree_p	active;
-    int		used;
-    mnode	nodes[MTREE_MNODE_N];
-    mtree_p	next;
+    mtree_p active;
+    int used;
+    mnode nodes[MTREE_MNODE_N];
+    mtree_p next;
 };
 
 #define MNODE_BUFSIZE 16384
@@ -33,86 +34,85 @@ struct _mtree_t
 int n_mnode_new = 0;
 int n_mnode_delete = 0;
 
-    INLINE static mnode*
+INLINE static mnode *
 mnode_new(mtree_p mtree)
 {
     mtree_p active = mtree->active;
 
     if (active->used >= MTREE_MNODE_N)
     {
-	active->next = (mtree_p)calloc(1, sizeof(*active->next));
-	// TODO: エラー処理
-	mtree->active = active->next;
-	active = active->next;
+        active->next = (mtree_p)calloc(1, sizeof(*active->next));
+        // TODO: エラー処理
+        mtree->active = active->next;
+        active = active->next;
     }
     ++n_mnode_new;
     return &active->nodes[active->used++];
 }
 
-    static void
-mnode_delete(mnode* p)
+static void
+mnode_delete(mnode *p)
 {
     while (p)
     {
-	mnode* child = p->child;
+        mnode *child = p->child;
 
-	if (p->list)
-	    wordlist_close(p->list);
-	if (p->next)
-	    mnode_delete(p->next);
-	//free(p);
-	p = child;
-	++n_mnode_delete;
+        if (p->list)
+            wordlist_close(p->list);
+        if (p->next)
+            mnode_delete(p->next);
+        // free(p);
+        p = child;
+        ++n_mnode_delete;
     }
 }
 
-
-    void
-mnode_print_stub(mnode* vp, unsigned char* p)
+void
+mnode_print_stub(mnode *vp, unsigned char *p)
 {
-    static unsigned char buf [256];
+    static unsigned char buf[256];
 
     if (!vp)
-	return;
+        return;
     if (!p)
-	p = &buf[0];
+        p = &buf[0];
     p[0] = MNODE_GET_CH(vp);
     p[1] = '\0';
     if (vp->list)
-	printf("%s (list=%p)\n", buf, vp->list);
+        printf("%s (list=%p)\n", buf, vp->list);
     if (vp->child)
-	mnode_print_stub(vp->child, p + 1);
+        mnode_print_stub(vp->child, p + 1);
     if (vp->next)
-	mnode_print_stub(vp->next, p);
+        mnode_print_stub(vp->next, p);
 }
 
-    void
-mnode_print(mtree_p mtree, unsigned char* p)
+void
+mnode_print(mtree_p mtree, unsigned char *p)
 {
     if (mtree && mtree->used > 0)
-	mnode_print_stub(&mtree->nodes[0], p);
+        mnode_print_stub(&mtree->nodes[0], p);
 }
 
-    void
+void
 mnode_close(mtree_p mtree)
 {
     if (mtree)
     {
-	mtree_p next;
+        mtree_p next;
 
-	if (mtree->used > 0)
-	    mnode_delete(&mtree->nodes[0]);
+        if (mtree->used > 0)
+            mnode_delete(&mtree->nodes[0]);
 
-	while (mtree)
-	{
-	    next = mtree->next;
-	    free(mtree);
-	    mtree = next;
-	}
+        while (mtree)
+        {
+            next = mtree->next;
+            free(mtree);
+            mtree = next;
+        }
     }
 }
 
-    INLINE static mnode*
+INLINE static mnode *
 search_or_new_mnode(mtree_p mtree, wordbuf_p buf)
 {
     // ラベル単語が決定したら検索木に追加
@@ -127,19 +127,19 @@ search_or_new_mnode(mtree_p mtree, wordbuf_p buf)
     ppnext = &root;
     while ((ch = *word) != 0)
     {
-	res = ppnext;
-	if (! *res)
-	{
-	    *res = mnode_new(mtree);
-	    MNODE_SET_CH(*res, ch);
-	}
-	else if (MNODE_GET_CH(*res) != ch)
-	{
-	    ppnext = &(*res)->next;
-	    continue;
-	}
-	ppnext = &(*res)->child;
-	++word;
+        res = ppnext;
+        if (!*res)
+        {
+            *res = mnode_new(mtree);
+            MNODE_SET_CH(*res, ch);
+        }
+        else if (MNODE_GET_CH(*res) != ch)
+        {
+            ppnext = &(*res)->next;
+            continue;
+        }
+        ppnext = &(*res)->child;
+        ++word;
     }
 
     _ASSERT(*res != NULL);
@@ -147,8 +147,8 @@ search_or_new_mnode(mtree_p mtree, wordbuf_p buf)
 }
 
 // 既存のノードにファイルからデータをまとめて追加する。
-    mtree_p
-mnode_load(mtree_p mtree, FILE* fp)
+mtree_p
+mnode_load(mtree_p mtree, FILE *fp)
 {
     mnode *pp = NULL;
     int mode = 0;
@@ -165,7 +165,7 @@ mnode_load(mtree_p mtree, FILE* fp)
     prevlabel = wordbuf_open();
     if (!fp || !buf || !prevlabel)
     {
-	goto END_MNODE_LOAD;
+        goto END_MNODE_LOAD;
     }
 
     // EOFの処理が曖昧。不正な形式のファイルが入った場合を考慮していない。各
@@ -173,106 +173,106 @@ mnode_load(mtree_p mtree, FILE* fp)
     // タファイルは絶対に間違っていないという前提を置く。
     do
     {
-	if (cache_ptr >= cache_tail)
-	{
-	    cache_ptr = cache;
-	    cache_tail = cache + fread(cache, 1, MNODE_BUFSIZE, fp);
-	    ch = (cache_tail <= cache && feof(fp)) ? EOF : *cache_ptr;
-	}
-	else
-	    ch = *cache_ptr;
-	++cache_ptr;
+        if (cache_ptr >= cache_tail)
+        {
+            cache_ptr = cache;
+            cache_tail = cache + fread(cache, 1, MNODE_BUFSIZE, fp);
+            ch = (cache_tail <= cache && feof(fp)) ? EOF : *cache_ptr;
+        }
+        else
+            ch = *cache_ptr;
+        ++cache_ptr;
 
-	// 状態:modeのオートマトン
-	switch (mode)
-	{
-	    case 0: // ラベル単語検索モード
-		// 空白はラベル単語になりえません
-		if (isspace(ch) || ch == EOF)
-		    continue;
-		// コメントラインチェック
-		else if (ch == ';')
-		{
-		    mode = 2; // 行末まで食い潰すモード へ移行
-		    continue;
-		}
-		else
-		{
-		    mode = 1; // ラベル単語の読込モード へ移行
-		    wordbuf_reset(buf);
-		    wordbuf_add(buf, (unsigned char)ch);
-		}
-		break;
+        // 状態:modeのオートマトン
+        switch (mode)
+        {
+            case 0: // ラベル単語検索モード
+                // 空白はラベル単語になりえません
+                if (isspace(ch) || ch == EOF)
+                    continue;
+                // コメントラインチェック
+                else if (ch == ';')
+                {
+                    mode = 2; // 行末まで食い潰すモード へ移行
+                    continue;
+                }
+                else
+                {
+                    mode = 1; // ラベル単語の読込モード へ移行
+                    wordbuf_reset(buf);
+                    wordbuf_add(buf, (unsigned char)ch);
+                }
+                break;
 
-	    case 1: // ラベル単語の読込モード
-		// ラベルの終了を検出
-		switch (ch)
-		{
-		    default:
-			wordbuf_add(buf, (unsigned char)ch);
-			break;
-		    case '\t':
-			pp = search_or_new_mnode(mtree, buf);
-			wordbuf_reset(buf);
-			mode = 3; // 単語前空白読飛ばしモード へ移行
-			break;
-		}
-		break;
+            case 1: // ラベル単語の読込モード
+                // ラベルの終了を検出
+                switch (ch)
+                {
+                    default:
+                        wordbuf_add(buf, (unsigned char)ch);
+                        break;
+                    case '\t':
+                        pp = search_or_new_mnode(mtree, buf);
+                        wordbuf_reset(buf);
+                        mode = 3; // 単語前空白読飛ばしモード へ移行
+                        break;
+                }
+                break;
 
-	    case 2: // 行末まで食い潰すモード
-		if (ch == '\n')
-		{
-		    wordbuf_reset(buf);
-		    mode = 0; // ラベル単語検索モード へ戻る
-		}
-		break;
+            case 2: // 行末まで食い潰すモード
+                if (ch == '\n')
+                {
+                    wordbuf_reset(buf);
+                    mode = 0; // ラベル単語検索モード へ戻る
+                }
+                break;
 
-	    case 3: // 単語前空白読み飛ばしモード
-		if (ch == '\n')
-		{
-		    wordbuf_reset(buf);
-		    mode = 0; // ラベル単語検索モード へ戻る
-		}
-		else if (ch != '\t')
-		{
-		    // 単語バッファリセット
-		    wordbuf_reset(buf);
-		    wordbuf_add(buf, (unsigned char)ch);
-		    // 単語リストの最後を検索(同一ラベルが複数時)
-		    ppword = &pp->list;
-		    while (*ppword)
-			ppword = &(*ppword)->next;
-		    mode = 4; // 単語の読み込みモード へ移行
-		}
-		break;
+            case 3: // 単語前空白読み飛ばしモード
+                if (ch == '\n')
+                {
+                    wordbuf_reset(buf);
+                    mode = 0; // ラベル単語検索モード へ戻る
+                }
+                else if (ch != '\t')
+                {
+                    // 単語バッファリセット
+                    wordbuf_reset(buf);
+                    wordbuf_add(buf, (unsigned char)ch);
+                    // 単語リストの最後を検索(同一ラベルが複数時)
+                    ppword = &pp->list;
+                    while (*ppword)
+                        ppword = &(*ppword)->next;
+                    mode = 4; // 単語の読み込みモード へ移行
+                }
+                break;
 
-	    case 4: // 単語の読み込みモード
-		switch (ch)
-		{
-		    case '\t':
-		    case '\n':
-			// 単語を記憶
-			*ppword = wordlist_open_len(WORDBUF_GET(buf),
-				WORDBUF_LEN(buf));
-			wordbuf_reset(buf);
+            case 4: // 単語の読み込みモード
+                switch (ch)
+                {
+                    case '\t':
+                    case '\n':
+                        // 単語を記憶
+                        *ppword = wordlist_open_len(
+                                WORDBUF_GET(buf), WORDBUF_LEN(buf));
+                        wordbuf_reset(buf);
 
-			if (ch == '\t')
-			{
-			    ppword = &(*ppword)->next;
-			    mode = 3; // 単語前空白読み飛ばしモード へ戻る
-			}
-			else
-			{
-			    ppword = NULL;
-			    mode = 0; // ラベル単語検索モード へ戻る
-			}
-			break;
-		    default:
-			wordbuf_add(buf, (unsigned char)ch);
-			break;
-		}
-		break;
-	}
+                        if (ch == '\t')
+                        {
+                            ppword = &(*ppword)->next;
+                            mode = 3; // 単語前空白読み飛ばしモード へ戻る
+                        }
+                        else
+                        {
+                            ppword = NULL;
+                            mode = 0; // ラベル単語検索モード へ戻る
+                        }
+                        break;
+                    default:
+                        wordbuf_add(buf, (unsigned char)ch);
+                        break;
+                }
+                break;
+        }
     }
     while (ch != EOF);
 
@@ -282,15 +282,15 @@ END_MNODE_LOAD:
     return mtree;
 }
 
-    mtree_p
-mnode_open(FILE* fp)
+mtree_p
+mnode_open(FILE *fp)
 {
     mtree_p mtree;
 
     mtree = (mtree_p)calloc(1, sizeof(*mtree));
     mtree->active = mtree;
     if (mtree && fp)
-	mnode_load(mtree, fp);
+        mnode_load(mtree, fp);
 
     return mtree;
 }
@@ -303,47 +303,50 @@ mnode_size(mnode* p)
 }
 #endif
 
-    static mnode*
-mnode_query_stub(mnode* node, const unsigned char* query)
+static mnode *
+mnode_query_stub(mnode *node, const unsigned char *query)
 {
     while (1)
     {
-	if (*query == MNODE_GET_CH(node))
-	    return (*++query == '\0') ? node :
-		(node->child ? mnode_query_stub(node->child, query) : NULL);
-	if (!(node = node->next))
-	    break;
+        if (*query == MNODE_GET_CH(node))
+            return (*++query == '\0')
+                           ? node
+                           : (node->child ? mnode_query_stub(node->child, query)
+                                          : NULL);
+        if (!(node = node->next))
+            break;
     }
     return NULL;
 }
 
-    mnode*
-mnode_query(mtree_p mtree, const unsigned char* query)
+mnode *
+mnode_query(mtree_p mtree, const unsigned char *query)
 {
     return (query && *query != '\0' && mtree)
-	? mnode_query_stub(&mtree->nodes[0], query) : 0;
+                   ? mnode_query_stub(&mtree->nodes[0], query)
+                   : 0;
 }
 
-    static void
-mnode_traverse_stub(mnode* node, MNODE_TRAVERSE_PROC proc, void* data)
+static void
+mnode_traverse_stub(mnode *node, MNODE_TRAVERSE_PROC proc, void *data)
 {
     while (1)
     {
-	if (node->child)
-	    mnode_traverse_stub(node->child, proc, data);
-	proc(node, data);
-	if (!(node = node->next))
-	    break;
+        if (node->child)
+            mnode_traverse_stub(node->child, proc, data);
+        proc(node, data);
+        if (!(node = node->next))
+            break;
     }
 }
 
-    void
-mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void* data)
+void
+mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void *data)
 {
     if (node && proc)
     {
-	proc(node, data);
-	if (node->child)
-	    mnode_traverse_stub(node->child, proc, data);
+        proc(node, data);
+        if (node->child)
+            mnode_traverse_stub(node->child, proc, data);
     }
 }

--- a/src/mnode.h
+++ b/src/mnode.h
@@ -1,4 +1,5 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // mnode.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -7,23 +8,25 @@
 #ifndef MNODE_H
 #define MNODE_H
 
+#include "wordlist.h"
+
 // ツリーオブジェクト
 typedef struct _mnode mnode;
 struct _mnode
 {
     unsigned int attr;
-    mnode* next;
-    mnode* child;
+    mnode *next;
+    mnode *child;
     wordlist_p list;
 };
-#define MNODE_MASK_CH		0x000000FF
-#define MNODE_GET_CH(p)		((unsigned char)(p)->attr)
-#define MNODE_SET_CH(p,c)	((p)->attr = (c))
+#define MNODE_MASK_CH      0x000000FF
+#define MNODE_GET_CH(p)    ((unsigned char)(p)->attr)
+#define MNODE_SET_CH(p, c) ((p)->attr = (c))
 
 typedef struct _mtree_t mtree_t, *mtree_p;
 
 // for mnode_traverse()
-typedef void (*mnode_traverse_proc)(mnode* node, void* data);
+typedef void (*mnode_traverse_proc)(mnode *node, void *data);
 #define MNODE_TRAVERSE_PROC mnode_traverse_proc
 
 extern int n_mnode_new;
@@ -33,18 +36,17 @@ extern int n_mnode_delete;
 extern "C" {
 #endif
 
-mtree_p mnode_open(FILE* fp);
-mtree_p mnode_load(mtree_p root, FILE* fp);
+mtree_p mnode_open(FILE *fp);
+mtree_p mnode_load(mtree_p root, FILE *fp);
 void mnode_close(mtree_p p);
-mnode* mnode_query(mtree_p node, const unsigned char* query);
-void mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void* data);
+mnode *mnode_query(mtree_p node, const unsigned char *query);
+void mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void *data);
 
 // 主にデバッグ用途
-void mnode_print(mtree_p mtree, unsigned char* p);
+void mnode_print(mtree_p mtree, unsigned char *p);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // MNODE_H

--- a/src/mnode.h
+++ b/src/mnode.h
@@ -5,8 +5,7 @@
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 // Need to include <stdio.h>
 
-#ifndef MNODE_H
-#define MNODE_H
+#pragma once
 
 #include "wordlist.h"
 
@@ -48,5 +47,3 @@ void mnode_print(mtree_p mtree, unsigned char *p);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // MNODE_H

--- a/src/resource.h
+++ b/src/resource.h
@@ -6,10 +6,10 @@
 // Next default values for new objects
 //
 #ifdef APSTUDIO_INVOKED
-#ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        101
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
-#endif
+# ifndef APSTUDIO_READONLY_SYMBOLS
+#  define _APS_NEXT_RESOURCE_VALUE 101
+#  define _APS_NEXT_COMMAND_VALUE  40001
+#  define _APS_NEXT_CONTROL_VALUE  1000
+#  define _APS_NEXT_SYMED_VALUE    101
+# endif
 #endif

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -1,15 +1,17 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // romaji.c - ローマ字変換
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include "wordbuf.h"
+
 #include "charset.h"
 #include "romaji.h"
+#include "wordbuf.h"
 
 #if defined(_MSC_VER) || defined(__GNUC__)
 # define INLINE __inline
@@ -18,9 +20,11 @@
 #endif
 
 #ifdef _DEBUG
-# define VERBOSE(o,l,b)	if ((o)->verbose >= (l)) { b }
+// clang-format off
+# define VERBOSE(o,l,b)     if ((o)->verbose >= (l)) { b }
+// clang-format on
 #else
-# define VERBOSE(o,l,b)
+# define VERBOSE(o, l, b)
 #endif
 
 #if defined(_MSC_VER)
@@ -29,9 +33,9 @@
 # define STRDUP strdup
 #endif
 
-#define ROMAJI_FIXKEY_N 'n'
-#define ROMAJI_FIXKEY_XN "xn"
-#define ROMAJI_FIXKEY_XTU "xtu"
+#define ROMAJI_FIXKEY_N      'n'
+#define ROMAJI_FIXKEY_XN     "xn"
+#define ROMAJI_FIXKEY_XTU    "xtu"
 #define ROMAJI_FIXKEY_NONXTU "aiueon"
 
 // romanode interfaces
@@ -40,66 +44,66 @@ typedef struct _romanode romanode;
 struct _romanode
 {
     unsigned char key;
-    unsigned char* value;
-    romanode* next;
-    romanode* child;
+    unsigned char *value;
+    romanode *next;
+    romanode *child;
 };
 
 int n_romanode_new = 0;
 int n_romanode_delete = 0;
 
-    INLINE static romanode*
+INLINE static romanode *
 romanode_new()
 {
     ++n_romanode_new;
-    return (romanode*)calloc(1, sizeof(romanode));
+    return (romanode *)calloc(1, sizeof(romanode));
 }
 
-    static void
-romanode_delete(romanode* node)
+static void
+romanode_delete(romanode *node)
 {
     while (node)
     {
-	romanode* child = node->child;
-	if (node->next)
-	    romanode_delete(node->next);
-	free(node->value);
-	free(node);
-	node = child;
-	++n_romanode_delete;
+        romanode *child = node->child;
+        if (node->next)
+            romanode_delete(node->next);
+        free(node->value);
+        free(node);
+        node = child;
+        ++n_romanode_delete;
     }
 }
 
-    static romanode**
-romanode_dig(romanode** ref_node, const unsigned char* key)
+static romanode **
+romanode_dig(romanode **ref_node, const unsigned char *key)
 {
     if (!ref_node || !key || key[0] == '\0')
-	return NULL;
+        return NULL;
 
     while (1)
     {
-	if (!*ref_node)
-	{
-	    if (!(*ref_node = romanode_new()))
-		return NULL;
-	    (*ref_node)->key = *key;
-	}
+        if (!*ref_node)
+        {
+            if (!(*ref_node = romanode_new()))
+                return NULL;
+            (*ref_node)->key = *key;
+        }
 
-	if ((*ref_node)->key == *key)
-	{
-	    (*ref_node)->value = NULL;
-	    if (!*++key)
-		break;
-	    ref_node = &(*ref_node)->child;
-	}
-	else
-	    ref_node = &(*ref_node)->next;
+        if ((*ref_node)->key == *key)
+        {
+            (*ref_node)->value = NULL;
+            if (!*++key)
+                break;
+            ref_node = &(*ref_node)->child;
+        }
+        else
+            ref_node = &(*ref_node)->next;
     }
 
     if ((*ref_node)->child)
     {
-	romanode_delete((*ref_node)->child);
-	(*ref_node)->child = 0;
+        romanode_delete((*ref_node)->child);
+        (*ref_node)->child = 0;
     }
     return ref_node;
 }
@@ -109,50 +113,51 @@ romanode_dig(romanode** ref_node, const unsigned char* key)
 /// @param node ルートノード
 /// @param key 検索キー
 /// @param skip 進めるべきkeyのバイト数を受け取るポインタ
-    static romanode*
-romanode_query(romanode* node, const unsigned char* key, int* skip,
-	ROMAJI_PROC_CHAR2INT char2int)
+static romanode *
+romanode_query(romanode *node, const unsigned char *key, int *skip,
+        ROMAJI_PROC_CHAR2INT char2int)
 {
     int nskip = 0;
-    const unsigned char* key_start = key;
+    const unsigned char *key_start = key;
 
-    //printf("romanode_query: key=%s skip=%p char2int=%p\n", key, skip, char2int);
+    // printf("romanode_query: key=%s skip=%p char2int=%p\n", key, skip,
+    // char2int);
     if (node && key && *key)
     {
-	while (1)
-	{
-	    if (*key != node->key)
-		node = node->next;
-	    else
-	    {
-		++nskip;
-		if (node->value)
-		{
-		    //printf("  HERE 1\n");
-		    break;
-		}
-		if (!*++key)
-		{
-		    nskip = 0;
-		    //printf("  HERE 2\n");
-		    break;
-		}
-		node = node->child;
-	    }
-	    // 次に走査するノードが空の場合、キーを進めてNULLを返す
-	    if (!node)
-	    {
-		// 1バイトではなく1文字進める
-		if (!char2int || (nskip = (*char2int)(key_start, NULL)) < 1)
-		    nskip = 1;
-		//printf("  HERE 3: nskip=%d\n", nskip);
-		break;
-	    }
-	}
+        while (1)
+        {
+            if (*key != node->key)
+                node = node->next;
+            else
+            {
+                ++nskip;
+                if (node->value)
+                {
+                    // printf("  HERE 1\n");
+                    break;
+                }
+                if (!*++key)
+                {
+                    nskip = 0;
+                    // printf("  HERE 2\n");
+                    break;
+                }
+                node = node->child;
+            }
+            // 次に走査するノードが空の場合、キーを進めてNULLを返す
+            if (!node)
+            {
+                // 1バイトではなく1文字進める
+                if (!char2int || (nskip = (*char2int)(key_start, NULL)) < 1)
+                    nskip = 1;
+                // printf("  HERE 3: nskip=%d\n", nskip);
+                break;
+            }
+        }
     }
 
     if (skip)
-	*skip = nskip;
+        *skip = nskip;
     return node;
 }
 
@@ -188,83 +193,83 @@ romanode_print(romanode* node)
 struct _romaji
 {
     int verbose;
-    romanode* node;
-    unsigned char* fixvalue_xn;
-    unsigned char* fixvalue_xtu;
+    romanode *node;
+    unsigned char *fixvalue_xn;
+    unsigned char *fixvalue_xtu;
     ROMAJI_PROC_CHAR2INT char2int;
 };
 
-    static unsigned char*
-strdup_lower(const unsigned char* string)
+static unsigned char *
+strdup_lower(const unsigned char *string)
 {
     unsigned char *out = STRDUP(string), *tmp;
 
     if (out)
-	for (tmp = out; *tmp; ++tmp)
-	    *tmp = (unsigned char)tolower(*tmp);
+        for (tmp = out; *tmp; ++tmp)
+            *tmp = (unsigned char)tolower(*tmp);
     return out;
 }
 
-    romaji*
+romaji *
 romaji_open()
 {
-    return (romaji*)calloc(1, sizeof(romaji));
+    return (romaji *)calloc(1, sizeof(romaji));
 }
 
-    void
-romaji_close(romaji* object)
+void
+romaji_close(romaji *object)
 {
     if (object)
     {
-	if (object->node)
-	    romanode_delete(object->node);
-	free(object->fixvalue_xn);
-	free(object->fixvalue_xtu);
-	free(object);
+        if (object->node)
+            romanode_delete(object->node);
+        free(object->fixvalue_xn);
+        free(object->fixvalue_xtu);
+        free(object);
     }
 }
 
-    int
-romaji_add_table(romaji* object, const unsigned char* key,
-	const unsigned char* value)
+int
+romaji_add_table(
+        romaji *object, const unsigned char *key, const unsigned char *value)
 {
     size_t value_length;
     romanode **ref_node;
 
     if (!object || !key || !value)
-	return 1; // Unexpected error
+        return 1; // Unexpected error
 
     value_length = strlen(value);
     if (value_length == 0)
-	return 2; // Too short value string
+        return 2; // Too short value string
 
     if (!(ref_node = romanode_dig(&object->node, key)))
     {
-	return 4; // Memory exhausted
+        return 4; // Memory exhausted
     }
     VERBOSE(object, 10,
-	    printf("romaji_add_table(\"%s\", \"%s\")\n", key, value););
+            printf("romaji_add_table(\"%s\", \"%s\")\n", key, value););
     (*ref_node)->value = STRDUP(value);
 
     // 「ん」と「っ」は保存しておく
     if (object->fixvalue_xn == NULL && value_length > 0
-	    && !strcmp(key, ROMAJI_FIXKEY_XN))
+            && !strcmp(key, ROMAJI_FIXKEY_XN))
     {
-	//fprintf(stderr, "XN: key=%s, value=%s\n", key, value);
-	object->fixvalue_xn = STRDUP(value);
+        // fprintf(stderr, "XN: key=%s, value=%s\n", key, value);
+        object->fixvalue_xn = STRDUP(value);
     }
     if (object->fixvalue_xtu == NULL && value_length > 0
-	    && !strcmp(key, ROMAJI_FIXKEY_XTU))
+            && !strcmp(key, ROMAJI_FIXKEY_XTU))
     {
-	//fprintf(stderr, "XTU: key=%s, value=%s\n", key, value);
-	object->fixvalue_xtu = STRDUP(value);
+        // fprintf(stderr, "XTU: key=%s, value=%s\n", key, value);
+        object->fixvalue_xtu = STRDUP(value);
     }
 
     return 0;
 }
 
-    int
-romaji_load_stub(romaji* object, FILE* fp)
+int
+romaji_load_stub(romaji *object, FILE *fp)
 {
     int mode, ch;
     wordbuf_p buf_key;
@@ -274,75 +279,75 @@ romaji_load_stub(romaji* object, FILE* fp)
     buf_value = wordbuf_open();
     if (!buf_key || !buf_value)
     {
-	wordbuf_close(buf_key);
-	wordbuf_close(buf_value);
-	return -1;
+        wordbuf_close(buf_key);
+        wordbuf_close(buf_value);
+        return -1;
     }
 
     mode = 0;
     do
     {
-	ch = fgetc(fp);
-	switch (mode)
-	{
-	    case 0:
-		// key待ちモード
-		if (ch == '#')
-		{
-		    // 1文字先読みして空白ならばkeyとして扱う
-		    ch = fgetc(fp);
-		    if (ch != '#')
-		    {
-			ungetc(ch, fp);
-			mode = 1; // 行末まで読み飛ばしモード へ移行
-			break;
-		    }
-		}
-		if (ch != EOF && !isspace(ch))
-		{
-		    wordbuf_reset(buf_key);
-		    wordbuf_add(buf_key, (unsigned char)ch);
-		    mode = 2; // key読み込みモード へ移行
-		}
-		break;
+        ch = fgetc(fp);
+        switch (mode)
+        {
+            case 0:
+                // key待ちモード
+                if (ch == '#')
+                {
+                    // 1文字先読みして空白ならばkeyとして扱う
+                    ch = fgetc(fp);
+                    if (ch != '#')
+                    {
+                        ungetc(ch, fp);
+                        mode = 1; // 行末まで読み飛ばしモード へ移行
+                        break;
+                    }
+                }
+                if (ch != EOF && !isspace(ch))
+                {
+                    wordbuf_reset(buf_key);
+                    wordbuf_add(buf_key, (unsigned char)ch);
+                    mode = 2; // key読み込みモード へ移行
+                }
+                break;
 
-	    case 1:
-		// 行末まで読み飛ばしモード
-		if (ch == '\n')
-		    mode = 0; // key待ちモード へ移行
-		break;
+            case 1:
+                // 行末まで読み飛ばしモード
+                if (ch == '\n')
+                    mode = 0; // key待ちモード へ移行
+                break;
 
-	    case 2:
-		// key読み込みモード
-		if (!isspace(ch))
-		    wordbuf_add(buf_key, (unsigned char)ch);
-		else
-		    mode = 3; // value待ちモード へ移行
-		break;
+            case 2:
+                // key読み込みモード
+                if (!isspace(ch))
+                    wordbuf_add(buf_key, (unsigned char)ch);
+                else
+                    mode = 3; // value待ちモード へ移行
+                break;
 
-	    case 3:
-		// value待ちモード
-		if (ch != EOF && !isspace(ch))
-		{
-		    wordbuf_reset(buf_value);
-		    wordbuf_add(buf_value, (unsigned char)ch);
-		    mode = 4; // value読み込みモード へ移行
-		}
-		break;
+            case 3:
+                // value待ちモード
+                if (ch != EOF && !isspace(ch))
+                {
+                    wordbuf_reset(buf_value);
+                    wordbuf_add(buf_value, (unsigned char)ch);
+                    mode = 4; // value読み込みモード へ移行
+                }
+                break;
 
-	    case 4:
-		// value読み込みモード
-		if (ch != EOF && !isspace(ch))
-		    wordbuf_add(buf_value, (unsigned char)ch);
-		else
-		{
-		    unsigned char *key = WORDBUF_GET(buf_key);
-		    unsigned char *value = WORDBUF_GET(buf_value);
-		    romaji_add_table(object, key, value);
-		    mode = 0;
-		}
-		break;
-	}
+            case 4:
+                // value読み込みモード
+                if (ch != EOF && !isspace(ch))
+                    wordbuf_add(buf_value, (unsigned char)ch);
+                else
+                {
+                    unsigned char *key = WORDBUF_GET(buf_key);
+                    unsigned char *value = WORDBUF_GET(buf_value);
+                    romaji_add_table(object, key, value);
+                    mode = 0;
+                }
+                break;
+        }
     }
     while (ch != EOF);
 
@@ -355,30 +360,30 @@ romaji_load_stub(romaji* object, FILE* fp)
 /// @param object ローマ字オブジェクト
 /// @param filename 辞書ファイル名
 /// @return 成功した場合0、失敗した場合は非0を返す。
-    int
-romaji_load(romaji* object, const unsigned char* filename)
+int
+romaji_load(romaji *object, const unsigned char *filename)
 {
     FILE *fp;
     int charset;
     if (!object || !filename)
-	return -1;
+        return -1;
 #if 1
     charset = charset_detect_file(filename);
-    charset_getproc(charset, (CHARSET_PROC_CHAR2INT*)&object->char2int, NULL);
+    charset_getproc(charset, (CHARSET_PROC_CHAR2INT *)&object->char2int, NULL);
 #endif
     if ((fp = fopen(filename, "rt")) != NULL)
     {
-	int result = result = romaji_load_stub(object, fp);
-	fclose(fp);
-	return result;
+        int result = result = romaji_load_stub(object, fp);
+        fclose(fp);
+        return result;
     }
     else
-	return -1;
+        return -1;
 }
 
-    unsigned char*
-romaji_convert2(romaji* object, const unsigned char* string,
-	unsigned char** ppstop, int ignorecase)
+unsigned char *
+romaji_convert2(romaji *object, const unsigned char *string,
+        unsigned char **ppstop, int ignorecase)
 {
     // Argument "ppstop" receive conversion stoped position.
     wordbuf_p buf = NULL;
@@ -389,93 +394,97 @@ romaji_convert2(romaji* object, const unsigned char* string,
 
     if (ignorecase)
     {
-	lower = strdup_lower(string);
-	input = lower;
+        lower = strdup_lower(string);
+        input = lower;
     }
 
     if (object && string && input && (buf = wordbuf_open()))
     {
-	int i;
+        int i;
 
-	for (i = 0; string[i]; )
-	{
-	    romanode *node;
-	    int skip;
+        for (i = 0; string[i];)
+        {
+            romanode *node;
+            int skip;
 
-	    // 「っ」の判定
-	    if (object->fixvalue_xtu && input[i] == input[i + 1]
-		    && !strchr(ROMAJI_FIXKEY_NONXTU, input[i]))
-	    {
-		++i;
-		wordbuf_cat(buf, object->fixvalue_xtu);
-		continue;
-	    }
+            // 「っ」の判定
+            if (object->fixvalue_xtu && input[i] == input[i + 1]
+                    && !strchr(ROMAJI_FIXKEY_NONXTU, input[i]))
+            {
+                ++i;
+                wordbuf_cat(buf, object->fixvalue_xtu);
+                continue;
+            }
 
-	    node = romanode_query(object->node, &input[i], &skip, object->char2int);
-	    VERBOSE(object, 1, printf("key=%s value=%s skip=%d\n", &input[i], node && node->value ? (char*)node->value : "null" , skip);)
-	    if (skip == 0)
-	    {
-		if (string[i])
-		{
-		    stop = WORDBUF_LEN(buf);
-		    wordbuf_cat(buf, &string[i]);
-		}
-		break;
-	    }
-	    else if (!node)
-	    {
-		// 「n(子音)」を「ん(子音)」に変換
-		if (skip == 1 && input[i] == ROMAJI_FIXKEY_N
-			&& object->fixvalue_xn)
-		{
-		    ++i;
-		    wordbuf_cat(buf, object->fixvalue_xn);
-		}
-		else
-		    while (skip--)
-			wordbuf_add(buf, string[i++]);
-	    }
-	    else
-	    {
-		i += skip;
-		wordbuf_cat(buf, node->value);
-	    }
-	}
-	answer = STRDUP(WORDBUF_GET(buf));
+            node = romanode_query(
+                    object->node, &input[i], &skip, object->char2int);
+            VERBOSE(object, 1,
+                    printf("key=%s value=%s skip=%d\n", &input[i],
+                            node && node->value ? (char *)node->value : "null",
+                            skip);)
+            if (skip == 0)
+            {
+                if (string[i])
+                {
+                    stop = WORDBUF_LEN(buf);
+                    wordbuf_cat(buf, &string[i]);
+                }
+                break;
+            }
+            else if (!node)
+            {
+                // 「n(子音)」を「ん(子音)」に変換
+                if (skip == 1 && input[i] == ROMAJI_FIXKEY_N
+                        && object->fixvalue_xn)
+                {
+                    ++i;
+                    wordbuf_cat(buf, object->fixvalue_xn);
+                }
+                else
+                    while (skip--)
+                        wordbuf_add(buf, string[i++]);
+            }
+            else
+            {
+                i += skip;
+                wordbuf_cat(buf, node->value);
+            }
+        }
+        answer = STRDUP(WORDBUF_GET(buf));
     }
     if (ppstop)
-	*ppstop = (stop >= 0) ? answer + stop : NULL;
+        *ppstop = (stop >= 0) ? answer + stop : NULL;
 
     if (lower)
-	free(lower);
+        free(lower);
     if (buf)
-	wordbuf_close(buf);
+        wordbuf_close(buf);
     return answer;
 }
 
-    unsigned char*
-romaji_convert(romaji* object, const unsigned char* string,
-	unsigned char** ppstop)
+unsigned char *
+romaji_convert(
+        romaji *object, const unsigned char *string, unsigned char **ppstop)
 {
     return romaji_convert2(object, string, ppstop, 1);
 }
 
-    void
-romaji_release(romaji* object, unsigned char* string)
+void
+romaji_release(romaji *object, unsigned char *string)
 {
     free(string);
 }
 
-    void
-romaji_setproc_char2int(romaji* object, ROMAJI_PROC_CHAR2INT proc)
+void
+romaji_setproc_char2int(romaji *object, ROMAJI_PROC_CHAR2INT proc)
 {
     if (object)
-	object->char2int = proc;
+        object->char2int = proc;
 }
 
-    void
-romaji_set_verbose(romaji* object, int level)
+void
+romaji_set_verbose(romaji *object, int level)
 {
     if (object)
-	object->verbose = level;
+        object->verbose = level;
 }

--- a/src/romaji.h
+++ b/src/romaji.h
@@ -1,4 +1,5 @@
-// vi:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // romaji.h - ローマ字変換
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -7,26 +8,26 @@
 #define ROMAJI_H
 
 typedef struct _romaji romaji;
-typedef int (*romaji_proc_char2int)(const unsigned char*, unsigned int*);
+typedef int (*romaji_proc_char2int)(const unsigned char *, unsigned int *);
 #define ROMAJI_PROC_CHAR2INT romaji_proc_char2int
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-romaji* romaji_open();
-void romaji_close(romaji* object);
-int romaji_add_table(romaji* object, const unsigned char* key,
-	const unsigned char* value);
-int romaji_load(romaji* object, const unsigned char* filename);
-unsigned char* romaji_convert(romaji* object, const unsigned char* string,
-	unsigned char** ppstop);
-unsigned char* romaji_convert2(romaji* object, const unsigned char* string,
-	unsigned char** ppstop, int ignorecase);
-void romaji_release(romaji* object, unsigned char* string);
+romaji *romaji_open();
+void romaji_close(romaji *object);
+int romaji_add_table(
+        romaji *object, const unsigned char *key, const unsigned char *value);
+int romaji_load(romaji *object, const unsigned char *filename);
+unsigned char *romaji_convert(
+        romaji *object, const unsigned char *string, unsigned char **ppstop);
+unsigned char *romaji_convert2(romaji *object, const unsigned char *string,
+        unsigned char **ppstop, int ignorecase);
+void romaji_release(romaji *object, unsigned char *string);
 
-void romaji_setproc_char2int(romaji* object, ROMAJI_PROC_CHAR2INT proc);
-void romaji_set_verbose(romaji* object, int level);
+void romaji_setproc_char2int(romaji *object, ROMAJI_PROC_CHAR2INT proc);
+void romaji_set_verbose(romaji *object, int level);
 
 #ifdef __cplusplus
 }

--- a/src/romaji.h
+++ b/src/romaji.h
@@ -4,8 +4,7 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-#ifndef ROMAJI_H
-#define ROMAJI_H
+#pragma once
 
 typedef struct _romaji romaji;
 typedef int (*romaji_proc_char2int)(const unsigned char *, unsigned int *);
@@ -32,5 +31,3 @@ void romaji_set_verbose(romaji *object, int level);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // ROMAJI_H

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -1,4 +1,5 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // rxgen.c - regular expression generator
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -7,8 +8,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "wordbuf.h"
 #include "rxgen.h"
+#include "wordbuf.h"
 
 #if defined(_MSC_VER)
 # define STRDUP _strdup
@@ -17,15 +18,15 @@
 #endif
 
 #define RXGEN_ENC_SJISTINY
-//#define RXGEN_OP_VIM
+// #define RXGEN_OP_VIM
 
-#define RXGEN_OP_MAXLEN 8
-#define RXGEN_OP_OR "|"
-#define RXGEN_OP_NEST_IN "("
-#define RXGEN_OP_NEST_OUT ")"
-#define RXGEN_OP_SELECT_IN "["
+#define RXGEN_OP_MAXLEN     8
+#define RXGEN_OP_OR         "|"
+#define RXGEN_OP_NEST_IN    "("
+#define RXGEN_OP_NEST_OUT   ")"
+#define RXGEN_OP_SELECT_IN  "["
 #define RXGEN_OP_SELECT_OUT "]"
-#define RXGEN_OP_NEWLINE ""
+#define RXGEN_OP_NEWLINE    ""
 
 int n_rnode_new = 0;
 int n_rnode_delete = 0;
@@ -50,193 +51,198 @@ struct _rxgen
 struct _rnode
 {
     unsigned int code;
-    rnode* child;
-    rnode* next;
+    rnode *child;
+    rnode *next;
 };
 
-    static rnode*
+static rnode *
 rnode_new()
 {
     ++n_rnode_new;
-    return (rnode*)calloc(1, sizeof(rnode));
+    return (rnode *)calloc(1, sizeof(rnode));
 }
 
-    static void
-rnode_delete(rnode* node)
+static void
+rnode_delete(rnode *node)
 {
     while (node)
     {
-	rnode* child = node->child;
-	if (node->next)
-	    rnode_delete(node->next);
-	free(node);
-	node = child;
-	++n_rnode_delete;
+        rnode *child = node->child;
+        if (node->next)
+            rnode_delete(node->next);
+        free(node);
+        node = child;
+        ++n_rnode_delete;
     }
 }
 
 // rxgen interfaces
 
-    static int
-default_char2int(const unsigned char* in, unsigned int* out)
+static int
+default_char2int(const unsigned char *in, unsigned int *out)
 {
     if (out)
-	*out = *in;
+        *out = *in;
     return 1;
 }
 
-    static int
-default_int2char(unsigned int in, unsigned char* out)
+static int
+default_int2char(unsigned int in, unsigned char *out)
 {
     int len = 0;
     // outは最低でも16バイトはある、という仮定を置く
     switch (in)
     {
-	case '\\':
-	case '.': case '*': case '^': case '$': case '/':
+        case '\\':
+        case '.':
+        case '*':
+        case '^':
+        case '$':
+        case '/':
 #ifdef RXGEN_OP_VIM
-	case '[': case ']': case '~':
+        case '[':
+        case ']':
+        case '~':
 #endif
-	    if (out)
-		out[len] = '\\';
-	    ++len;
-	default:
-	    if (out)
-		out[len] = (unsigned char)(in & 0xFF);
-	    ++len;
-	    break;
+            if (out)
+                out[len] = '\\';
+            ++len;
+        default:
+            if (out)
+                out[len] = (unsigned char)(in & 0xFF);
+            ++len;
+            break;
     }
     return len;
 }
 
-    void
-rxgen_setproc_char2int(rxgen* object, RXGEN_PROC_CHAR2INT proc)
+void
+rxgen_setproc_char2int(rxgen *object, RXGEN_PROC_CHAR2INT proc)
 {
     if (object)
-	object->char2int = proc ? proc : default_char2int;
+        object->char2int = proc ? proc : default_char2int;
 }
 
-    void
-rxgen_setproc_int2char(rxgen* object, RXGEN_PROC_INT2CHAR proc)
+void
+rxgen_setproc_int2char(rxgen *object, RXGEN_PROC_INT2CHAR proc)
 {
     if (object)
-	object->int2char = proc ? proc : default_int2char;
+        object->int2char = proc ? proc : default_int2char;
 }
 
-    static int
-rxgen_call_char2int(rxgen* object, const unsigned char* pch,
-	unsigned int* code)
+static int
+rxgen_call_char2int(rxgen *object, const unsigned char *pch, unsigned int *code)
 {
     int len = object->char2int(pch, code);
     return len ? len : default_char2int(pch, code);
 }
 
-    static int
-rxgen_call_int2char(rxgen* object, unsigned int code, unsigned char* buf)
+static int
+rxgen_call_int2char(rxgen *object, unsigned int code, unsigned char *buf)
 {
     int len = object->int2char(code, buf);
     return len ? len : default_int2char(code, buf);
 }
 
-    rxgen*
+rxgen *
 rxgen_open()
 {
-    rxgen* object = (rxgen*)calloc(1, sizeof(rxgen));
+    rxgen *object = (rxgen *)calloc(1, sizeof(rxgen));
     if (object)
     {
-	rxgen_setproc_char2int(object, NULL);
-	rxgen_setproc_int2char(object, NULL);
-	strcpy(object->op_or,		RXGEN_OP_OR);
-	strcpy(object->op_nest_in,	RXGEN_OP_NEST_IN);
-	strcpy(object->op_nest_out,	RXGEN_OP_NEST_OUT);
-	strcpy(object->op_select_in,	RXGEN_OP_SELECT_IN);
-	strcpy(object->op_select_out,	RXGEN_OP_SELECT_OUT);
-	strcpy(object->op_newline,	RXGEN_OP_NEWLINE);
+        rxgen_setproc_char2int(object, NULL);
+        rxgen_setproc_int2char(object, NULL);
+        strcpy(object->op_or, RXGEN_OP_OR);
+        strcpy(object->op_nest_in, RXGEN_OP_NEST_IN);
+        strcpy(object->op_nest_out, RXGEN_OP_NEST_OUT);
+        strcpy(object->op_select_in, RXGEN_OP_SELECT_IN);
+        strcpy(object->op_select_out, RXGEN_OP_SELECT_OUT);
+        strcpy(object->op_newline, RXGEN_OP_NEWLINE);
     }
     return object;
 }
 
-    void
-rxgen_close(rxgen* object)
+void
+rxgen_close(rxgen *object)
 {
     if (object)
     {
-	rnode_delete(object->node);
-	free(object);
+        rnode_delete(object->node);
+        free(object);
     }
 }
 
-    static rnode*
-search_rnode(rnode** phead, unsigned int code)
+static rnode *
+search_rnode(rnode **phead, unsigned int code)
 {
     rnode **pp = phead;
     while (*pp && (*pp)->code != code)
-	pp = &(*pp)->next;
+        pp = &(*pp)->next;
 
     if (*pp && pp != phead)
     {
-	rnode *found = *pp;
-	*pp = found->next;
-	found->next = *phead;
-	*phead = found;
-	return found;
+        rnode *found = *pp;
+        *pp = found->next;
+        found->next = *phead;
+        *phead = found;
+        return found;
     }
     return *pp;
 }
 
-    int
-rxgen_add(rxgen* object, const unsigned char* word)
+int
+rxgen_add(rxgen *object, const unsigned char *word)
 {
     rnode **ppnode;
     rnode *pnode;
 
     if (!object || !word)
-	return 0;
+        return 0;
 
     ppnode = &object->node;
     while (1)
     {
-	unsigned int code;
-	int len = rxgen_call_char2int(object, word, &code);
-	//printf("rxgen_call_char2int: code=%08x\n", code);
+        unsigned int code;
+        int len = rxgen_call_char2int(object, word, &code);
+        // printf("rxgen_call_char2int: code=%08x\n", code);
 
-	// 入力パターンが尽きたら終了
-	if (code == 0)
-	{
-	    // 入力パターンよりも長い既存パターンは破棄する
-	    if (*ppnode)
-	    {
-		rnode_delete(*ppnode);
-		*ppnode = NULL;
-	    }
-	    break;
-	}
-	pnode = search_rnode(ppnode, code);
-	if (pnode == NULL)
-	{
-	    // codeを持つノードが無い場合、作成追加する
-	    pnode = rnode_new();
-	    pnode->code = code;
-	    pnode->next = *ppnode;
-	    *ppnode = pnode;
-	}
-	else if (pnode->child == NULL)
-	{
-	    // codeを持つノードは有るが、その子供が無い場合、それ以降の入力
-	    // パターンは破棄する。例:
-	    //     あかい + あかるい -> あか
-	    //	   たのしい + たのしみ -> たのし
-	    break;
-	}
-	// 子ノードを辿って深い方へ注視点を移動
-	ppnode = &pnode->child;
-	word += len;
+        // 入力パターンが尽きたら終了
+        if (code == 0)
+        {
+            // 入力パターンよりも長い既存パターンは破棄する
+            if (*ppnode)
+            {
+                rnode_delete(*ppnode);
+                *ppnode = NULL;
+            }
+            break;
+        }
+        pnode = search_rnode(ppnode, code);
+        if (pnode == NULL)
+        {
+            // codeを持つノードが無い場合、作成追加する
+            pnode = rnode_new();
+            pnode->code = code;
+            pnode->next = *ppnode;
+            *ppnode = pnode;
+        }
+        else if (pnode->child == NULL)
+        {
+            // codeを持つノードは有るが、その子供が無い場合、それ以降の入力
+            // パターンは破棄する。例:
+            //     あかい + あかるい -> あか
+            //	   たのしい + たのしみ -> たのし
+            break;
+        }
+        // 子ノードを辿って深い方へ注視点を移動
+        ppnode = &pnode->child;
+        word += len;
     }
     return 1;
 }
 
-    static void
-rxgen_generate_stub(rxgen* object, wordbuf_t* buf, rnode* node)
+static void
+rxgen_generate_stub(rxgen *object, wordbuf_t *buf, rnode *node)
 {
     unsigned char ch[16];
     int chlen, nochild, haschild = 0, brother = 1;
@@ -245,10 +251,10 @@ rxgen_generate_stub(rxgen* object, wordbuf_t* buf, rnode* node)
     // 現在の階層の特性(兄弟の数、子供の数)をチェックする
     for (tmp = node; tmp; tmp = tmp->next)
     {
-	if (tmp->next)
-	    ++brother;
-	if (tmp->child)
-	    ++haschild;
+        if (tmp->next)
+            ++brother;
+        if (tmp->child)
+            ++haschild;
     }
     nochild = brother - haschild;
 #if 0 // For debug
@@ -257,132 +263,133 @@ rxgen_generate_stub(rxgen* object, wordbuf_t* buf, rnode* node)
 #endif
     // 必要ならば()によるグルーピング
     if (brother > 1 && haschild > 0)
-	wordbuf_cat(buf, object->op_nest_in);
+        wordbuf_cat(buf, object->op_nest_in);
 #if 1
     // 子の無いノードを先に[]によりグルーピング
     if (nochild > 0)
     {
-	if (nochild > 1)
-	    wordbuf_cat(buf, object->op_select_in);
-	for (tmp = node; tmp; tmp = tmp->next)
-	{
-	    if (tmp->child)
-		continue;
-	    chlen = rxgen_call_int2char(object, tmp->code, ch);
-	    ch[chlen] = '\0';
-	    //printf("nochild: %s\n", ch);
-	    wordbuf_cat(buf, ch);
-	}
-	if (nochild > 1)
-	    wordbuf_cat(buf, object->op_select_out);
+        if (nochild > 1)
+            wordbuf_cat(buf, object->op_select_in);
+        for (tmp = node; tmp; tmp = tmp->next)
+        {
+            if (tmp->child)
+                continue;
+            chlen = rxgen_call_int2char(object, tmp->code, ch);
+            ch[chlen] = '\0';
+            // printf("nochild: %s\n", ch);
+            wordbuf_cat(buf, ch);
+        }
+        if (nochild > 1)
+            wordbuf_cat(buf, object->op_select_out);
     }
 #endif
 #if 1
     // 子のあるノードを出力
     if (haschild > 0)
     {
-	// グループを出力済みならORで繋ぐ
-	if (nochild > 0)
-	    wordbuf_cat(buf, object->op_or);
-	for (tmp = node; !tmp->child; tmp = tmp->next)
-	    ;
-	while (1)
-	{
-	    chlen = rxgen_call_int2char(object, tmp->code, ch);
-	    //printf("code=%04X len=%d\n", tmp->code, chlen);
-	    ch[chlen] = '\0';
-	    wordbuf_cat(buf, ch);
-	    // 空白・改行飛ばしのパターンを挿入
-	    if (object->op_newline[0])
-		wordbuf_cat(buf, object->op_newline);
-	    rxgen_generate_stub(object, buf, tmp->child);
-	    for (tmp = tmp->next; tmp && !tmp->child; tmp = tmp->next)
-		;
-	    if (!tmp)
-		break;
-	    if (haschild > 1)
-		wordbuf_cat(buf, object->op_or);
-	}
+        // グループを出力済みならORで繋ぐ
+        if (nochild > 0)
+            wordbuf_cat(buf, object->op_or);
+        for (tmp = node; !tmp->child; tmp = tmp->next)
+            ;
+        while (1)
+        {
+            chlen = rxgen_call_int2char(object, tmp->code, ch);
+            // printf("code=%04X len=%d\n", tmp->code, chlen);
+            ch[chlen] = '\0';
+            wordbuf_cat(buf, ch);
+            // 空白・改行飛ばしのパターンを挿入
+            if (object->op_newline[0])
+                wordbuf_cat(buf, object->op_newline);
+            rxgen_generate_stub(object, buf, tmp->child);
+            for (tmp = tmp->next; tmp && !tmp->child; tmp = tmp->next)
+                ;
+            if (!tmp)
+                break;
+            if (haschild > 1)
+                wordbuf_cat(buf, object->op_or);
+        }
     }
 #endif
     // 必要ならば()によるグルーピング
     if (brother > 1 && haschild > 0)
-	wordbuf_cat(buf, object->op_nest_out);
+        wordbuf_cat(buf, object->op_nest_out);
 }
 
-    unsigned char*
-rxgen_generate(rxgen* object)
+unsigned char *
+rxgen_generate(rxgen *object)
 {
-    unsigned char* answer = NULL;
+    unsigned char *answer = NULL;
     wordbuf_t *buf;
 
     if (object && (buf = wordbuf_open()))
     {
-	if (object->node)
-	    rxgen_generate_stub(object, buf, object->node);
-	answer = STRDUP(WORDBUF_GET(buf));
-	wordbuf_close(buf);
+        if (object->node)
+            rxgen_generate_stub(object, buf, object->node);
+        answer = STRDUP(WORDBUF_GET(buf));
+        wordbuf_close(buf);
     }
     return answer;
 }
 
-    void
-rxgen_release(rxgen* object, unsigned char* string)
+void
+rxgen_release(rxgen *object, unsigned char *string)
 {
     free(string);
 }
 
 // rxgen_add()してきたパターンを全てリセット。
-    void
-rxgen_reset(rxgen* object)
+void
+rxgen_reset(rxgen *object)
 {
     if (object)
     {
-	rnode_delete(object->node);
-	object->node = NULL;
+        rnode_delete(object->node);
+        object->node = NULL;
     }
 }
 
-    static unsigned char*
-rxgen_get_operator_stub(rxgen* object, int index)
+static unsigned char *
+rxgen_get_operator_stub(rxgen *object, int index)
 {
     switch (index)
     {
-	case RXGEN_OPINDEX_OR:
-	    return object->op_or;
-	case RXGEN_OPINDEX_NEST_IN:
-	    return object->op_nest_in;
-	case RXGEN_OPINDEX_NEST_OUT:
-	    return object->op_nest_out;
-	case RXGEN_OPINDEX_SELECT_IN:
-	    return object->op_select_in;
-	case RXGEN_OPINDEX_SELECT_OUT:
-	    return object->op_select_out;
-	case RXGEN_OPINDEX_NEWLINE:
-	    return object->op_newline;
-	default:
-	    return NULL;
+        case RXGEN_OPINDEX_OR:
+            return object->op_or;
+        case RXGEN_OPINDEX_NEST_IN:
+            return object->op_nest_in;
+        case RXGEN_OPINDEX_NEST_OUT:
+            return object->op_nest_out;
+        case RXGEN_OPINDEX_SELECT_IN:
+            return object->op_select_in;
+        case RXGEN_OPINDEX_SELECT_OUT:
+            return object->op_select_out;
+        case RXGEN_OPINDEX_NEWLINE:
+            return object->op_newline;
+        default:
+            return NULL;
     }
 }
 
-    const unsigned char*
-rxgen_get_operator(rxgen* object, int index)
+const unsigned char *
+rxgen_get_operator(rxgen *object, int index)
 {
-    return (const unsigned char*)
-	(object ? rxgen_get_operator_stub(object, index) : NULL);
+    return (const unsigned char *)(object ? rxgen_get_operator_stub(
+                                                    object, index)
+                                          : NULL);
 }
 
-    int
-rxgen_set_operator(rxgen* object, int index, const unsigned char* op)
+int
+rxgen_set_operator(rxgen *object, int index, const unsigned char *op)
 {
-    unsigned char* dest;
+    unsigned char *dest;
 
     if (!object)
-	return 1; // Invalid object
+        return 1; // Invalid object
     if (strlen(op) >= RXGEN_OP_MAXLEN)
-	return 2; // Too long operator
+        return 2; // Too long operator
     if (!(dest = rxgen_get_operator_stub(object, index)))
-	return 3; // No such an operator
+        return 3; // No such an operator
     strcpy(dest, op);
 
     return 0;

--- a/src/rxgen.h
+++ b/src/rxgen.h
@@ -1,4 +1,5 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // rxgen.h - regular expression generator
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -7,18 +8,18 @@
 #define RXGEN_H
 
 typedef struct _rxgen rxgen;
-typedef int (*rxgen_proc_char2int)(const unsigned char*, unsigned int*);
-typedef int (*rxgen_proc_int2char)(unsigned int, unsigned char*);
+typedef int (*rxgen_proc_char2int)(const unsigned char *, unsigned int *);
+typedef int (*rxgen_proc_int2char)(unsigned int, unsigned char *);
 #define RXGEN_PROC_CHAR2INT rxgen_proc_char2int
 #define RXGEN_PROC_INT2CHAR rxgen_proc_int2char
 
 // for rxgen_set_operator
-#define RXGEN_OPINDEX_OR		0
-#define RXGEN_OPINDEX_NEST_IN		1
-#define RXGEN_OPINDEX_NEST_OUT		2
-#define RXGEN_OPINDEX_SELECT_IN		3
-#define RXGEN_OPINDEX_SELECT_OUT	4
-#define RXGEN_OPINDEX_NEWLINE		5
+#define RXGEN_OPINDEX_OR         0
+#define RXGEN_OPINDEX_NEST_IN    1
+#define RXGEN_OPINDEX_NEST_OUT   2
+#define RXGEN_OPINDEX_SELECT_IN  3
+#define RXGEN_OPINDEX_SELECT_OUT 4
+#define RXGEN_OPINDEX_NEWLINE    5
 
 extern int n_rnode_new;
 extern int n_rnode_delete;
@@ -27,17 +28,17 @@ extern int n_rnode_delete;
 extern "C" {
 #endif
 
-rxgen* rxgen_open();
-void rxgen_close(rxgen* object);
-int rxgen_add(rxgen* object, const unsigned char* word);
-unsigned char* rxgen_generate(rxgen* object);
-void rxgen_release(rxgen* object, unsigned char* string);
-void rxgen_reset(rxgen* object);
+rxgen *rxgen_open();
+void rxgen_close(rxgen *object);
+int rxgen_add(rxgen *object, const unsigned char *word);
+unsigned char *rxgen_generate(rxgen *object);
+void rxgen_release(rxgen *object, unsigned char *string);
+void rxgen_reset(rxgen *object);
 
-void rxgen_setproc_char2int(rxgen* object, RXGEN_PROC_CHAR2INT proc);
-void rxgen_setproc_int2char(rxgen* object, RXGEN_PROC_INT2CHAR proc);
-int rxgen_set_operator(rxgen* object, int index, const unsigned char* op);
-const unsigned char* rxgen_get_operator(rxgen* object, int index);
+void rxgen_setproc_char2int(rxgen *object, RXGEN_PROC_CHAR2INT proc);
+void rxgen_setproc_int2char(rxgen *object, RXGEN_PROC_INT2CHAR proc);
+int rxgen_set_operator(rxgen *object, int index, const unsigned char *op);
+const unsigned char *rxgen_get_operator(rxgen *object, int index);
 
 #ifdef __cplusplus
 }

--- a/src/rxgen.h
+++ b/src/rxgen.h
@@ -4,8 +4,7 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-#ifndef RXGEN_H
-#define RXGEN_H
+#pragma once
 
 typedef struct _rxgen rxgen;
 typedef int (*rxgen_proc_char2int)(const unsigned char *, unsigned int *);
@@ -43,5 +42,3 @@ const unsigned char *rxgen_get_operator(rxgen *object, int index);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // RXGEN_H

--- a/src/testdir/profile_speed.c
+++ b/src/testdir/profile_speed.c
@@ -1,4 +1,5 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // profile_speed.c - Query speed profiler.
 //
 // Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -7,20 +8,21 @@
 
 #include <stdio.h>
 #include <time.h>
+
 #include "migemo.h"
 
 #ifndef DICTDIR
 # define DICTDIR "../../dict"
 #endif
 
-#define CLOCK2SEC(t)    ((double)(t) / (double)CLOCKS_PER_SEC)
+#define CLOCK2SEC(t) ((double)(t) / (double)CLOCKS_PER_SEC)
 
-    int
-main(int argc, char** argv)
+int
+main(int argc, char **argv)
 {
-    migemo* pmig;
-    char* ans;
-    char key[2] = { '\0', '\0' };
+    migemo *pmig;
+    char *ans;
+    char key[2] = {'\0', '\0'};
     int i;
     clock_t clock_load = 0, clock_query = 0, clock_tmp = 0;
 

--- a/src/testdir/romaji_main.c
+++ b/src/testdir/romaji_main.c
@@ -1,11 +1,14 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // romaji_main.c - Romaji convert console.
 //
 // Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
+//
 // gcc -o romaji romaji_main.c ../romaji.c ../wordbuf.c
 
 #include <stdio.h>
 #include <string.h>
+
 #include "romaji.h"
 
 #ifndef DICTDIR
@@ -18,14 +21,15 @@
 # define DICT_HIRA2KATA (DICTDIR "/hira2kata.dat")
 #endif
 #ifndef DICT_HAN2ZEN
-# define DICT_HAN2ZEN   (DICTDIR "/han2zen.dat")
+# define DICT_HAN2ZEN (DICTDIR "/han2zen.dat")
 #endif
 #ifndef DICT_ZEN2HAN
-# define DICT_ZEN2HAN   (DICTDIR "/zen2han.dat")
+# define DICT_ZEN2HAN (DICTDIR "/zen2han.dat")
 #endif
 
-    void
-query_one(romaji* object, romaji* hira2kata, romaji* han2zen, romaji* zen2han, char* buf)
+void
+query_one(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han,
+        char *buf)
 {
     unsigned char *stop;
     unsigned char *hira;
@@ -34,7 +38,7 @@ query_one(romaji* object, romaji* hira2kata, romaji* han2zen, romaji* zen2han, c
     // ローマ字→平仮名(表示)→片仮名(表示)
     if ((hira = romaji_convert(object, buf, &stop)) != NULL)
     {
-        unsigned char* kata;
+        unsigned char *kata;
 
         printf("  hira=%s, stop=%s\n", hira, stop);
 #if 1
@@ -61,8 +65,8 @@ query_one(romaji* object, romaji* hira2kata, romaji* han2zen, romaji* zen2han, c
     fflush(stdout);
 }
 
-    void
-query_loop(romaji* object, romaji* hira2kata, romaji* han2zen, romaji* zen2han)
+void
+query_loop(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
 {
     char buf[256], *ans;
 
@@ -81,8 +85,8 @@ query_loop(romaji* object, romaji* hira2kata, romaji* han2zen, romaji* zen2han)
     }
 }
 
-    int
-main(int argc, char** argv)
+int
+main(int argc, char **argv)
 {
     romaji *object, *hira2kata, *han2zen, *zen2han;
     char *word = NULL;

--- a/src/wordbuf.c
+++ b/src/wordbuf.c
@@ -1,50 +1,52 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // wordbuf.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
+
 #include "wordbuf.h"
 
 #define WORDLEN_DEF 64
 
-int n_wordbuf_open = 0;		// for DEBUG
-int n_wordbuf_close = 0;	// for DEBUG
+int n_wordbuf_open = 0;  // for DEBUG
+int n_wordbuf_close = 0; // for DEBUG
 
 // function pre-declaration
 static int wordbuf_extend(wordbuf_p p, int len);
 
-    wordbuf_p
+wordbuf_p
 wordbuf_open()
 {
     wordbuf_p p = (wordbuf_p)malloc(sizeof(wordbuf_t));
 
     if (p)
     {
-	++n_wordbuf_open;	// for DEBUG
-	p->len = WORDLEN_DEF;
-	p->buf = (unsigned char*)malloc(p->len);
-	p->last = 0;
-	p->buf[0] = '\0';
+        ++n_wordbuf_open; // for DEBUG
+        p->len = WORDLEN_DEF;
+        p->buf = (unsigned char *)malloc(p->len);
+        p->last = 0;
+        p->buf[0] = '\0';
     }
     return p;
 }
 
-    void
+void
 wordbuf_close(wordbuf_p p)
 {
     if (p)
     {
-	++n_wordbuf_close;	// for DEBUG
-	free(p->buf);
-	free(p);
+        ++n_wordbuf_close; // for DEBUG
+        free(p->buf);
+        free(p);
     }
 }
 
-    void
+void
 wordbuf_reset(wordbuf_p p)
 {
     p->last = 0;
@@ -54,57 +56,57 @@ wordbuf_reset(wordbuf_p p)
 // wordbuf_extend(wordbuf_p p, int req_len);
 //	バッファの伸長。エラー時には0が帰る。
 //	高速化のために伸ばすべきかは呼出側で判断する。
-    static int
+static int
 wordbuf_extend(wordbuf_p p, int req_len)
 {
     int newlen = p->len * 2;
     unsigned char *newbuf;
 
     while (req_len > newlen)
-	newlen *= 2;
-    if (!(newbuf = (unsigned char*)realloc(p->buf, newlen)))
+        newlen *= 2;
+    if (!(newbuf = (unsigned char *)realloc(p->buf, newlen)))
     {
-	//fprintf(stderr, "wordbuf_add(): failed to extend buffer\n");
-	return 0;
+        // fprintf(stderr, "wordbuf_add(): failed to extend buffer\n");
+        return 0;
     }
     else
     {
-	p->len = newlen;
-	p->buf = newbuf;
-	return req_len;
+        p->len = newlen;
+        p->buf = newbuf;
+        return req_len;
     }
 }
 
-    int
+int
 wordbuf_last(wordbuf_p p)
 {
     return p->last;
 }
 
-    int
+int
 wordbuf_add(wordbuf_p p, unsigned char ch)
 {
     int newlen = p->last + 2;
 
     if (newlen > p->len && !wordbuf_extend(p, newlen))
-	return 0;
+        return 0;
     else
     {
 #if 1
-	unsigned char *buf = p->buf + p->last;
+        unsigned char *buf = p->buf + p->last;
 
-	buf[0] = ch;
-	buf[1] = '\0';
+        buf[0] = ch;
+        buf[1] = '\0';
 #else
-	// リトルエンディアンを仮定するなら使えるが…
-	*(unsigned short*)&p->buf[p->last] = (unsigned short)ch;
+        // リトルエンディアンを仮定するなら使えるが…
+        *(unsigned short *)&p->buf[p->last] = (unsigned short)ch;
 #endif
-	return ++p->last;
+        return ++p->last;
     }
 }
 
-    int
-wordbuf_cat(wordbuf_p p, const unsigned char* sz)
+int
+wordbuf_cat(wordbuf_p p, const unsigned char *sz)
 {
     int len = 0;
 
@@ -116,17 +118,17 @@ wordbuf_cat(wordbuf_p p, const unsigned char* sz)
 
     if (len > 0)
     {
-	int newlen = p->last + len + 1;
+        int newlen = p->last + len + 1;
 
-	if (newlen > p->len && !wordbuf_extend(p, newlen))
-	    return 0;
-	memcpy(&p->buf[p->last], sz, len + 1);
-	p->last = p->last + len;
+        if (newlen > p->len && !wordbuf_extend(p, newlen))
+            return 0;
+        memcpy(&p->buf[p->last], sz, len + 1);
+        p->last = p->last + len;
     }
     return p->last;
 }
 
-    unsigned char*
+unsigned char *
 wordbuf_get(wordbuf_p p)
 {
     return p->buf;

--- a/src/wordbuf.h
+++ b/src/wordbuf.h
@@ -1,7 +1,9 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // wordbuf.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
+
 #ifndef WORDBUF_H
 #define WORDBUF_H
 
@@ -9,7 +11,7 @@ typedef struct _wordbuf_t wordbuf_t, *wordbuf_p;
 struct _wordbuf_t
 {
     int len; // bufに割り当てられているメモリ量
-    unsigned char* buf;
+    unsigned char *buf;
     int last; // bufに実際に格納している文字列の長さ
 };
 
@@ -29,8 +31,8 @@ void wordbuf_close(wordbuf_p p);
 void wordbuf_reset(wordbuf_p p);
 int wordbuf_last(wordbuf_p p);
 int wordbuf_add(wordbuf_p p, unsigned char ch);
-int wordbuf_cat(wordbuf_p p, const unsigned char* sz);
-unsigned char* wordbuf_get(wordbuf_p p);
+int wordbuf_cat(wordbuf_p p, const unsigned char *sz);
+unsigned char *wordbuf_get(wordbuf_p p);
 
 #ifdef __cplusplus
 }

--- a/src/wordbuf.h
+++ b/src/wordbuf.h
@@ -4,8 +4,7 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-#ifndef WORDBUF_H
-#define WORDBUF_H
+#pragma once
 
 typedef struct _wordbuf_t wordbuf_t, *wordbuf_p;
 struct _wordbuf_t
@@ -37,5 +36,3 @@ unsigned char *wordbuf_get(wordbuf_p p);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // WORDBUF_H

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -1,43 +1,45 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // wordlist.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
+
 #include "wordlist.h"
 
-int n_wordlist_open	= 0;
-int n_wordlist_close	= 0;
-int n_wordlist_total	= 0;
+int n_wordlist_open = 0;
+int n_wordlist_close = 0;
+int n_wordlist_total = 0;
 
-    wordlist_p
-wordlist_open_len(const unsigned char* ptr, int len)
+wordlist_p
+wordlist_open_len(const unsigned char *ptr, int len)
 {
     if (ptr && len >= 0)
     {
-	wordlist_p p;
+        wordlist_p p;
 
-	if ((p = (wordlist_p)malloc(sizeof(*p) + len + 1)) != NULL)
-	{
-	    p->ptr  = (char*)(p + 1);
-	    p->next = NULL;
-	    // ほぼstrdup()と等価な実装。単語の保存に必要な総メモリを知りた
-	    // いので独自に再実装。
-	    memcpy(p->ptr, ptr, len);
-	    p->ptr[len] = '\0';
+        if ((p = (wordlist_p)malloc(sizeof(*p) + len + 1)) != NULL)
+        {
+            p->ptr = (char *)(p + 1);
+            p->next = NULL;
+            // ほぼstrdup()と等価な実装。単語の保存に必要な総メモリを知りた
+            // いので独自に再実装。
+            memcpy(p->ptr, ptr, len);
+            p->ptr[len] = '\0';
 
-	    ++n_wordlist_open;
-	    n_wordlist_total += len;
-	}
-	return p;
+            ++n_wordlist_open;
+            n_wordlist_total += len;
+        }
+        return p;
     }
     return NULL;
 }
 
-    wordlist_p
-wordlist_open(const unsigned char* ptr)
+wordlist_p
+wordlist_open(const unsigned char *ptr)
 {
     wordlist_p p = NULL;
     if (ptr != NULL)
@@ -49,15 +51,15 @@ wordlist_open(const unsigned char* ptr)
     return p;
 }
 
-    void
+void
 wordlist_close(wordlist_p p)
 {
     while (p)
     {
-	wordlist_p next = p->next;
+        wordlist_p next = p->next;
 
-	++n_wordlist_close;
-	free(p);
-	p = next;
+        ++n_wordlist_close;
+        free(p);
+        p = next;
     }
 }

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -4,8 +4,7 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-#ifndef WORDLIST_H
-#define WORDLIST_H
+#pragma once
 
 typedef struct _wordlist_t wordlist_t, *wordlist_p;
 struct _wordlist_t
@@ -29,5 +28,3 @@ void wordlist_close(wordlist_p p);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // WORDLIST_H

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -1,4 +1,5 @@
-// vim:set ts=8 sts=4 sw=4 tw=0:
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
 // wordlist.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
@@ -9,7 +10,7 @@
 typedef struct _wordlist_t wordlist_t, *wordlist_p;
 struct _wordlist_t
 {
-    unsigned char* ptr;
+    unsigned char *ptr;
     wordlist_p next;
 };
 
@@ -21,8 +22,8 @@ extern int n_wordlist_total;
 extern "C" {
 #endif
 
-wordlist_p wordlist_open(const unsigned char* ptr);
-wordlist_p wordlist_open_len(const unsigned char* ptr, int len);
+wordlist_p wordlist_open(const unsigned char *ptr);
+wordlist_p wordlist_open_len(const unsigned char *ptr, int len);
 void wordlist_close(wordlist_p p);
 
 #ifdef __cplusplus

--- a/test/main.c
+++ b/test/main.c
@@ -4,8 +4,8 @@
 
 int test1(void);
 
-    int
-main(int argc, char** argv)
+int
+main(int argc, char **argv)
 {
     int r;
     if ((r = test1()) != 0)

--- a/test/test1.c
+++ b/test/test1.c
@@ -2,18 +2,19 @@
 
 #include <stdio.h>
 #include <string.h>
+
 #include "migemo.h"
 
-    static int
+static int
 assert_query(migemo *p, const char *q, const char *ex)
 {
-    char    *r;
+    char *r;
 
     r = migemo_query(p, q);
     if (strcmp(r, ex) != 0)
     {
-        printf("Failed: query \"%s\" generate \"%s\" (expected \"%s\")\n",
-                q, r, ex);
+        printf("Failed: query \"%s\" generate \"%s\" (expected \"%s\")\n", q, r,
+                ex);
         migemo_release(p, r);
         return 1;
     }
@@ -21,11 +22,12 @@ assert_query(migemo *p, const char *q, const char *ex)
     return 0;
 }
 
-    static int
+static int
 test_all(migemo *p)
 {
-    if (assert_query(p, "ak",
-                "([明悪秋朱紅赤]|あ([こけくきか]|っ[こけくきか])|ak)") != 0)
+    if (assert_query(
+                p, "ak", "([明悪秋朱紅赤]|あ([こけくきか]|っ[こけくきか])|ak)")
+            != 0)
         return 1;
     if (assert_query(p, "n", "[んのねぬになn]") != 0)
         return 1;
@@ -34,11 +36,11 @@ test_all(migemo *p)
     return 0;
 }
 
-    int
+int
 test1(void)
 {
-    int     r;
-    migemo  *p;
+    int r;
+    migemo *p;
 
     p = migemo_open("test1/migemo-dict");
     if (p == NULL)


### PR DESCRIPTION
## Summary
Introduced `clang-format` to establish a consistent coding style across the codebase and reformatted existing files accordingly. Additionally, updated the header guards in `src/*.h` to `#pragma once` for better readability and maintainability.

## Changes
- **Add `.clang-format`**: Defined project-wide coding style rules.
- **Apply Code Formatting**: Reformatted codebase to conform with the new `.clang-format` configuration.
- **Update Makefile**: Added a `format` target to easily format code and ensure style consistency.
- **Modernize Header Guards**: Replaced classic include guards (`#ifndef` / `#define`) with `#pragma once` across all `src/*.h` header files.

## Impact
- Code style and formatting across C/C++ source and header files (no functional or behavioral logic changes).