### PR TITLE
ci: modularize CI workflows into reusable per-platform files

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,59 @@
+name: CI on Linux
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-linux-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+
+    name: Build
+
+    strategy:
+      matrix:
+        include:
+        - { arch: aarch64, runner: ubuntu-24.04-arm, }
+        - { arch: x86_64,  runner: ubuntu-latest,    }
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+
+    - uses: actions/checkout@v7
+
+    - name: Build
+      run: |
+        cmake -B build
+        cmake --build build --parallel
+
+    - name: Test
+      run: cmake --build build --target test
+
+    - name: Profiling
+      run: |
+        cmake --build build --target profile
+        mv build/profile.log build/profile-linux-${{ matrix.arch }}.log
+
+    - name: Packaging
+      run: |
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --target package --parallel
+
+    - name: List files in build
+      run: tree -Fh build
+
+    - name: Upload profile.log
+      uses: actions/upload-artifact@v7
+      with:
+        path: build/profile-linux-*.log
+        archive: false
+
+    - name: Upload the package
+      uses: actions/upload-artifact@v7
+      with:
+        path: build/cmigemo-*.tar.gz
+        archive: false

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,50 @@
+name: CI on macOS
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-macos-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+
+    name: Build
+
+    runs-on: macos-latest
+
+    steps:
+
+    - name: Trust AWS Tap
+      run: brew trust aws/tap
+
+    - name: Install dependencies via Homebrew
+      run: |
+        brew update
+        brew install tree
+
+    - uses: actions/checkout@v7
+
+    - name: Build
+      run: |
+        cmake -B build
+        cmake --build build --parallel
+
+    - name: Test
+      run: cmake --build build --target test
+
+    - name: Packaging
+      run: |
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --target package --parallel
+
+    - name: List files in build
+      run: tree -Fh build
+
+    - name: Upload the package
+      uses: actions/upload-artifact@v7
+      with:
+        path: build/cmigemo-*.tar.gz
+        archive: false

--- a/.github/workflows/ci-windows-msvc.yml
+++ b/.github/workflows/ci-windows-msvc.yml
@@ -1,0 +1,71 @@
+name: CI on Windows (MSVC)
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-windows-msvc-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+
+    name: Build
+
+    runs-on: windows-2025-vs2026
+
+    defaults:
+      run:
+        shell: cmd
+
+    steps:
+    - name: Set up MSYS2 packages
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
+      id: msys2
+      with:
+        msystem: UCRT64
+        update:  true
+        release: false
+        pacboy: >-
+          cmake:p
+          iconv:
+          gzip:
+          perl:
+          tree:
+
+    - name: Setup MSYS2 PATH
+      run: |
+        echo ${{ steps.msys2.outputs.msys2-location }}\%MSYSTEM%\bin>> %GITHUB_PATH%
+        echo ${{ steps.msys2.outputs.msys2-location }}\usr\bin>> %GITHUB_PATH%
+
+    - name: Setup VC++ environment (VCVARSALL)
+      run: for /f "usebackq tokens=*" %%i in (`vswhere -products * -latest -property installationPath`) do (echo VCVARSALL=%%i\VC\Auxiliary\Build\vcvarsall.bat) >> %GITHUB_ENV%
+
+    - uses: actions/checkout@v7
+
+    - name: Build
+      run: |
+        call "%VCVARSALL%" amd64
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --parallel
+
+    - name: Test
+      run: |
+        call "%VCVARSALL%" amd64
+        cmake --build build --target test
+
+    - name: Packaging
+      run: |
+        call "%VCVARSALL%" amd64
+        cmake --build build --target package --parallel
+
+    - name: List files in build
+      shell: msys2 {0}
+      run: tree -Fh build
+
+    - name: Upload the package
+      uses: actions/upload-artifact@v7
+      with:
+        path: build/cmigemo-*.zip
+        archive: false

--- a/.github/workflows/ci-windows-ucrt64.yml
+++ b/.github/workflows/ci-windows-ucrt64.yml
@@ -1,0 +1,76 @@
+name: CI on Windows (UCRT64)
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-windows-ucrt64-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+
+    name: Build
+
+    runs-on: windows-2025-vs2026
+
+    defaults:
+      run:
+        shell: cmd
+
+    steps:
+    - name: Set up MSYS2 packages
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
+      id: msys2
+      with:
+        msystem: UCRT64
+        update:  true
+        release: false
+        pacboy: >-
+          cmake:p
+          gcc:p
+          iconv:
+          gzip:
+          perl:
+          tree:
+
+    - uses: actions/checkout@v7
+
+    - name: Build
+      shell: msys2 {0}
+      run: |
+        cmake -B build
+        cmake --build build --parallel
+
+    - name: Test
+      shell: msys2 {0}
+      run: cmake --build build --target test
+
+    - name: Profiling
+      shell: msys2 {0}
+      run: |
+        cmake --build build --target profile
+        mv build/profile.log build/profile-windows-ucrt64-amd64.log
+
+    - name: Packaging
+      shell: msys2 {0}
+      run: |
+        cmake -B build -DCMAKE_BUILD_TYPE=Release
+        cmake --build build --target package --parallel
+
+    - name: List files in build
+      shell: msys2 {0}
+      run: tree -Fh build
+
+    - name: Upload profile.log
+      uses: actions/upload-artifact@v7
+      with:
+        path: build/profile-windows-*.log
+        archive: false
+
+    - name: Upload the package
+      uses: actions/upload-artifact@v7
+      with:
+        path: build/cmigemo-*.zip
+        archive: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,216 +2,28 @@ name: CI
 
 on: [push]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
-  build-linux:
+  linux:
+    name: Linux (Ubuntu)
+    uses: ./.github/workflows/ci-linux.yml
+    secrets: inherit
 
-    name: Build on Linux
+  macos:
+    name: macOS
+    uses: ./.github/workflows/ci-macos.yml
+    secrets: inherit
 
-    strategy:
-      matrix:
-        include:
-        - { arch: aarch64, runner: ubuntu-24.04-arm, }
-        - { arch: x86_64,  runner: ubuntu-latest,    }
+  windows-ucrt64:
+    name: Windows (UCRT64)
+    uses: ./.github/workflows/ci-windows-ucrt64.yml
+    secrets: inherit
 
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-
-    - uses: actions/checkout@v7
-
-    - name: Build
-      run: |
-        cmake -B build
-        cmake --build build --parallel
-
-    - name: Test
-      run: cmake --build build --target test
-
-    - name: Profiling
-      run: |
-        cmake --build build --target profile
-        mv build/profile.log build/profile-linux-${{ matrix.arch }}.log
-
-    - name: Packaging
-      run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release
-        cmake --build build --target package --parallel
-
-    - name: List files in build
-      run: tree -Fh build
-
-    - name: Upload profile.log
-      uses: actions/upload-artifact@v7
-      with:
-        path: build/profile-linux-*.log
-        archive: false
-
-    - name: Upload the package
-      uses: actions/upload-artifact@v7
-      with:
-        path: build/cmigemo-*.tar.gz
-        archive: false
-
-  build-windows-ucrt64:
-
-    name: Build on Windows (ucrt64)
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        shell: cmd
-
-    steps:
-    - name: Set up MSYS2 packages
-      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
-      id: msys2
-      with:
-        msystem: UCRT64
-        update:  true
-        release: false
-        pacboy: >-
-          cmake:p
-          gcc:p
-          iconv:
-          gzip:
-          perl:
-          tree:
-
-    - uses: actions/checkout@v7
-
-    - name: Build
-      shell: msys2 {0}
-      run: |
-        cmake -B build
-        cmake --build build --parallel
-
-    - name: Test
-      shell: msys2 {0}
-      run: cmake --build build --target test
-
-    - name: Profiling
-      shell: msys2 {0}
-      run: |
-        cmake --build build --target profile
-        mv build/profile.log build/profile-windows-ucrt64-amd64.log
-
-    - name: Packaging
-      shell: msys2 {0}
-      run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release
-        cmake --build build --target package --parallel
-
-    - name: List files in build
-      shell: msys2 {0}
-      run: tree -Fh build
-
-    - name: Upload profile.log
-      uses: actions/upload-artifact@v7
-      with:
-        path: build/profile-windows-*.log
-        archive: false
-
-    - name: Upload the package
-      uses: actions/upload-artifact@v7
-      with:
-        path: build/cmigemo-*.zip
-        archive: false
-
-  build-windows-msvc:
-
-    name: Build on Windows (msvc)
-
-    runs-on: windows-2025-vs2026
-
-    defaults:
-      run:
-        shell: cmd
-
-    steps:
-    - name: Set up MSYS2 packages
-      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
-      id: msys2
-      with:
-        msystem: UCRT64
-        update:  true
-        release: false
-        pacboy: >-
-          cmake:p
-          iconv:
-          gzip:
-          perl:
-          tree:
-
-    - name: Setup MSYS2 PATH
-      run: |
-        echo ${{ steps.msys2.outputs.msys2-location }}\%MSYSTEM%\bin>> %GITHUB_PATH%
-        echo ${{ steps.msys2.outputs.msys2-location }}\usr\bin>> %GITHUB_PATH%
-
-    - name: Setup VC++ environment (VCVARSALL)
-      run: for /f "usebackq tokens=*" %%i in (`vswhere -products * -latest -property installationPath`) do (echo VCVARSALL=%%i\VC\Auxiliary\Build\vcvarsall.bat) >> %GITHUB_ENV%
-
-    - uses: actions/checkout@v7
-
-    - name: Build
-      run: |
-        call "%VCVARSALL%" amd64
-        cmake -B build -DCMAKE_BUILD_TYPE=Release
-        cmake --build build --parallel
-
-    - name: Test
-      run: |
-        call "%VCVARSALL%" amd64
-        cmake --build build --target test
-
-    - name: Packaging
-      run: |
-        call "%VCVARSALL%" amd64
-        cmake --build build --target package --parallel
-
-    - name: List files in build
-      shell: msys2 {0}
-      run: tree -Fh build
-
-    - name: Upload the package
-      uses: actions/upload-artifact@v7
-      with:
-        path: build/cmigemo-*.zip
-        archive: false
-
-  build-macos:
-
-    name: Build on macOS
-
-    runs-on: macos-latest
-
-    steps:
-    - name: Install dependencies via Homebrew
-      run: |
-        brew update
-        brew install tree
-
-    - uses: actions/checkout@v7
-
-    - name: Build
-      run: |
-        cmake -B build
-        cmake --build build --parallel
-
-    - name: Test
-      run: cmake --build build --target test
-
-    - name: Packaging
-      run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release
-        cmake --build build --target package --parallel
-
-    - name: List files in build
-      run: tree -Fh build
-
-    - name: Upload the package
-      uses: actions/upload-artifact@v7
-      with:
-        path: build/cmigemo-*.tar.gz
-        archive: false
+  windows-msvc:
+    name: Windows (MSVC)
+    uses: ./.github/workflows/ci-windows-msvc.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

Refactors the monolith `ci.yml` workflow by splitting platform-specific build jobs into dedicated sub-workflows using `workflow_call`. This improves workflow maintainability and allows independent modifications for each platform.

## Changes

- **Top-level workflow (`.github/workflows/ci.yml`)**:
  - Serves as the main entry point (`on: [push]`).
  - Calls sub-workflows using `workflow_call` with `secrets: inherit`.
  - Maintains top-level concurrency control.
- **Platform sub-workflows**:
  - Created `.github/workflows/ci-linux.yml` (Ubuntu x86_64 and aarch64 matrix).
  - Created `.github/workflows/ci-macos.yml` (macOS runner).
  - Created `.github/workflows/ci-windows-ucrt64.yml` (MSYS2 / UCRT64 environment).
  - Created `.github/workflows/ci-windows-msvc.yml` (Visual Studio / MSVC environment).
  - Configured independent concurrency cancellation for each platform workflow.