### PR TITLE
Fix error handling on memory allocation and prevent leaks in mnode

### DIFF
--- a/src/migemo.c
+++ b/src/migemo.c
@@ -210,8 +210,8 @@ migemo_open(const char *dict)
     obj->hira2kata = romaji_open();
     obj->han2zen = romaji_open();
     obj->zen2han = romaji_open();
-    if (!obj->rx || !obj->roma2hira || !obj->hira2kata || !obj->han2zen
-            || !obj->zen2han)
+    if (!obj->mtree || !obj->rx || !obj->roma2hira || !obj->hira2kata
+            || !obj->han2zen || !obj->zen2han)
     {
         migemo_close(obj);
         return obj = NULL;
@@ -319,13 +319,10 @@ add_roma(migemo *object, unsigned char *query)
         // 片仮名文字列を生成し候補に加える
         kata = romaji_convert2(object->hira2kata, hira, NULL, 0);
         migemo_addword(object, kata);
-        // TODO: 半角カナを生成し候補に加える
-#if 1
+        // 半角カナを生成し候補に加える
         han = romaji_convert2(object->zen2han, kata, NULL, 0);
         migemo_addword(object, han);
-        // printf("kata=%s\nhan=%s\n", kata, han);
         romaji_release(object->zen2han, han);
-#endif
         // カタカナによる辞書引き
         add_mnode_query(object, kata);
         romaji_release(object->hira2kata, kata); // カタカナ解放

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -40,10 +40,12 @@ mnode_new(mtree_p mtree)
 
     if (active->used >= MTREE_MNODE_N)
     {
-        active->next = (mtree_p)calloc(1, sizeof(*active->next));
-        // TODO: エラー処理
-        mtree->active = active->next;
-        active = active->next;
+        mtree_p p = (mtree_p)calloc(1, sizeof(*active->next));
+        if (!p)
+            return NULL;
+        active->next = p;
+        mtree->active = p;
+        active = p;
     }
     ++n_mnode_new;
     return &active->nodes[active->used++];
@@ -130,6 +132,8 @@ search_or_new_mnode(mtree_p mtree, wordbuf_p buf)
         if (!*res)
         {
             *res = mnode_new(mtree);
+            if (!(*res))
+                return NULL;
             MNODE_SET_CH(*res, ch);
         }
         else if (MNODE_GET_CH(*res) != ch)
@@ -163,6 +167,7 @@ mnode_load(mtree_p mtree, FILE *fp)
     prevlabel = wordbuf_open();
     if (!fp || !buf || !prevlabel)
     {
+        mtree = NULL;
         goto END_MNODE_LOAD;
     }
 
@@ -211,6 +216,11 @@ mnode_load(mtree_p mtree, FILE *fp)
                         break;
                     case '\t':
                         pp = search_or_new_mnode(mtree, buf);
+                        if (!pp)
+                        {
+                            mtree = NULL;
+                            goto END_MNODE_LOAD;
+                        }
                         wordbuf_reset(buf);
                         mode = 3; // 単語前空白読飛ばしモード へ移行
                         break;
@@ -288,7 +298,11 @@ mnode_open(FILE *fp)
     mtree = (mtree_p)calloc(1, sizeof(*mtree));
     mtree->active = mtree;
     if (mtree && fp)
-        mnode_load(mtree, fp);
+        if (!mnode_load(mtree, fp))
+        {
+            mnode_close(mtree);
+            return NULL;
+        }
 
     return mtree;
 }


### PR DESCRIPTION
- Add NULL check for `calloc` failures in `mnode_new()` and propagate errors to caller functions
- Prevent memory leaks in `mnode_open()` by invoking `mnode_close()` upon load failure
- Clean up outdated `TODO` comments and unused preprocessor directives in `migemo.c`