### PR TITLE
rxgen: Upgrade debug statistics profiling for rnode tree

### DIFF
--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -397,35 +397,87 @@ rxgen_generate_stub(rxgen *object, wordbuf_t *buf, rnode *node)
 
 #if RXGEN_DEBUG_STAT
 
-static void
-rnode_count_nodes(
-        rnode *node, int *all, int *low, int *high, int *maxdepth, int depth)
+typedef struct
 {
-    (*all)++;
-    depth++;
-    if (*maxdepth < depth)
-        *maxdepth = depth;
+    size_t total_nodes;
+    size_t low_count;
+    size_t high_count;
+    size_t child_count;
+    size_t wordtail_count;
+
+    int max_sibling_depth;
+    size_t total_sibling_depth;
+
+    int max_node_cmp_count;
+    size_t total_node_cmp_count;
+} rnode_stat;
+
+static void
+rnode_debug_stat_stub(
+        rnode *node, rnode_stat *stat, int sib_depth, int total_cmp)
+{
+    if (!node)
+        return;
+
+    stat->total_nodes++;
+    stat->total_sibling_depth += sib_depth;
+    if (sib_depth > stat->max_sibling_depth)
+        stat->max_sibling_depth = sib_depth;
+
+    stat->total_node_cmp_count += total_cmp;
+    if (total_cmp > stat->max_node_cmp_count)
+        stat->max_node_cmp_count = total_cmp;
+
     if (node->low)
-    {
-        (*low)++;
-        rnode_count_nodes(node->low, all, low, high, maxdepth, depth);
-    }
+        stat->low_count++;
     if (node->high)
-    {
-        (*high)++;
-        rnode_count_nodes(node->high, all, low, high, maxdepth, depth);
-    }
+        stat->high_count++;
+    if (node->child)
+        stat->child_count++;
+    if (node->wordtail)
+        stat->wordtail_count++;
+
+    if (node->low)
+        rnode_debug_stat_stub(node->low, stat, sib_depth + 1, total_cmp + 1);
+    if (node->high)
+        rnode_debug_stat_stub(node->high, stat, sib_depth + 1, total_cmp + 1);
+    if (node->child)
+        rnode_debug_stat_stub(node->child, stat, 0, total_cmp + 1);
 }
 
 static void
-rxgen_debug_stat(rnode *root)
+rnode_debug_stat(rnode *root)
 {
-    int all = 0, low = 0, high = 0, depth = 0;
-    if (root)
-        rnode_count_nodes(root, &all, &low, &high, &depth, 0);
-    printf("rxgen_debug_stat: all=%d, low=%d, high=%d, balance(high-low)=%d, "
-           "max depth=%d\n",
-            all, low, high, high - low, depth);
+    rnode_stat stat;
+    memset(&stat, 0, sizeof(stat));
+    if (!root)
+        return;
+
+    rnode_debug_stat_stub(root, &stat, 0, 1);
+
+    printf("=== rnode statistics ===\n");
+    printf("Total Nodes          : %zu\n", stat.total_nodes);
+    printf("Wordtail Nodes       : %zu\n", stat.wordtail_count);
+    printf("Pointer Counts       : low=%zu, high=%zu, child=%zu\n",
+            stat.low_count, stat.high_count, stat.child_count);
+    printf("Low/High Balance Ratio: %.2f%% / %.2f%%\n",
+            stat.low_count + stat.high_count > 0
+                    ? (double)stat.low_count
+                              / (stat.low_count + stat.high_count) * 100.0
+                    : 0.0,
+            stat.low_count + stat.high_count > 0
+                    ? (double)stat.high_count
+                              / (stat.low_count + stat.high_count) * 100.0
+                    : 0.0);
+    printf("Sibling Depth        : max=%d, avg=%.2f\n", stat.max_sibling_depth,
+            stat.total_nodes > 0
+                    ? (double)stat.total_sibling_depth / stat.total_nodes
+                    : 0.0);
+    printf("Node Compare Count   : max=%d, avg=%.2f\n", stat.max_node_cmp_count,
+            stat.total_nodes > 0
+                    ? (double)stat.total_node_cmp_count / stat.total_nodes
+                    : 0.0);
+    printf("======================\n");
 }
 
 #endif
@@ -442,7 +494,7 @@ rxgen_generate(rxgen *object)
         if (object->root)
         {
 #if RXGEN_DEBUG_STAT
-            rxgen_debug_stat(object->root);
+            rnode_debug_stat(object->root);
 #endif
             rxgen_generate_stub(object, buf, object->root);
         }


### PR DESCRIPTION
## Overview
This PR enhances the debug statistics feature (`RXGEN_DEBUG_STAT`) in `src/rxgen.c` to provide comprehensive structural analysis of the regular expression generation tree (`rnode`).

It refactors the previous basic node count stub into a detailed metrics collector matching the profiling capabilities used in `mnode`.

## Changes
- **Refactored `rnode_debug_stat`:** Replaced `rnode_count_nodes()` with `rnode_debug_stat_stub()` and the `rnode_stat` structure.
- **Detailed Metrics Collection:**
  - Tracks total node count, wordtail node count, and pointer distributions (`low`, `high`, `child`).
  - Calculates $Low/High$ balance ratio to monitor tree equilibrium.
  - Measures average and maximum **Sibling Depth** across branches.
  - Measures average and maximum **Node Comparison Counts** to quantify lookup complexity.
- **Zero Overhead:** Fully enclosed within `#if RXGEN_DEBUG_STAT` to ensure zero runtime/binary impact in release builds.

## Sample Profiling Output
When enabled, generating regex patterns produces structural metrics like the following:

```text
=== rnode statistics ===
Total Nodes          : 1304
Wordtail Nodes       : 1008
Pointer Counts       : low=506, high=501, child=296
Low/High Balance Ratio: 50.25% / 49.75%
Sibling Depth        : max=25, avg=9.58
Node Compare Count   : max=60, avg=14.55
======================