### PR TITLE
docs: add AGENTS.md and translate code comments to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Build System & Requirements
+
+- **Requirements**:
+  - Build: CMake (3.16+), C11 compiler (gcc, clang, msvc)
+  - Dictionary Generation: `curl`, `iconv`, `gzip`, `perl`
+  - Profiling: `gperf`
+- **Configure**: `cmake -B build` (Default build type is `Release`. For Debug: `cmake -B build -DCMAKE_BUILD_TYPE=Debug`)
+- **Build**: `cmake --build build --parallel`
+- **Test**: `cmake --build build --target test`
+- **Profiling**: `cmake --build build --target profile` (generates `build/profile.log`)
+- **Clean**: `cmake --build build --target clean` or `rm -rf build`
+
+## How to Run CLI Tool
+
+Build first, then execute with a generated dictionary:
+
+```console
+./build/src/cmigemo -d build/dict/utf-8/migemo-dict
+```
+
+Pass `-d <dict>` or `-s <subdict>` to specify custom dictionary paths.
+
+## Dictionary Generation
+
+* **Process**: Downloads `SKK-JISYO.L`, converts to UTF-8, and runs `dict/skk2migemo.pl` / `dict/optimize-dict.pl` to build base dictionary.
+* **Encodings**: Generates dictionaries for `utf-8`, `euc-jp`, and `cp932` under `build/dict/<encoding>/`.
+* **Default Encoding Target**:
+* Windows: `cp932`
+* Non-Windows: `utf-8`
+
+## Project Structure
+
+* `include/`: Public C API headers (`migemo.h`).
+* `src/`: Core library implementation (`migemo.c`, `rxgen.c`, `romaji.c`, etc.) and CLI executable (`main.c`).
+* `dict/`: Dictionary build scripts (`skk2migemo.pl`, `optimize-dict.pl`) and CMake targets.
+* `test/`: Unit tests (`test1`) and benchmarking/profiling utilities.
+
+## Coding Standards & Compiler Quirks
+
+* **Code Formatting**:
+* C/C++ files: LLVM style via `clang-format -i <file>`
+* CMake files: Configured via `.cmakefmt.yaml` (2-space indent, column limit 80)
+
+* **Editor Modelines**: Preserve editor headers in source files (e.g., `// vim:set ts=8 sts=4 sw=4 tw=0 et:`).
+* **MSVC Rules**: Requires `/utf-8` and `_CRT_SECURE_NO_WARNINGS`.
+
+## Install
+
+```console
+cmake --install build
+```
+
+Installs binaries/headers to standard system paths and dictionaries to `${CMAKE_INSTALL_DATADIR}/cmigemo/<encoding>/`.

--- a/include/migemo.h
+++ b/include/migemo.h
@@ -34,7 +34,7 @@
 typedef int (*MIGEMO_PROC_CHAR2INT)(const unsigned char *, unsigned int *);
 typedef int (*MIGEMO_PROC_INT2CHAR)(unsigned int, unsigned char *);
 
-/// Migemoオブジェクト。migemo_open()で作成され、migemo_closeで破棄される。
+/// Migemo object. Created by migemo_open() and destroyed by migemo_close.
 typedef struct _migemo migemo;
 
 #ifdef __cplusplus

--- a/src/charset.c
+++ b/src/charset.c
@@ -69,7 +69,7 @@ eucjp_char2int(const unsigned char *in, unsigned int *out)
 int
 eucjp_int2char(unsigned int in, unsigned char *out)
 {
-    // CP932と内容は同じだが将来JISX0213に対応させるために分離しておく
+    // Same as CP932, but separated to support JISX0213 in the future
     if (in >= 0x100)
     {
         if (out)
@@ -206,7 +206,7 @@ charset_detect_buf(const unsigned char *buf, int len)
     for (i = 0; i < len; ++i)
     {
         unsigned char c = buf[i];
-        // SJISであるかのチェック
+        // Check if it is SJIS
         if (smode)
         {
             if ((0x40 <= c && c <= 0x7e) || (0x80 <= c && c <= 0xfc))
@@ -215,7 +215,7 @@ charset_detect_buf(const unsigned char *buf, int len)
         }
         else if ((0x81 <= c && c <= 0x9f) || (0xe0 <= c && c <= 0xf0))
             smode = 1;
-        // EUCであるかのチェック
+        // Check if it is EUC
         eflag = 0xa1 <= c && c <= 0xfe;
         if (emode)
         {
@@ -225,7 +225,7 @@ charset_detect_buf(const unsigned char *buf, int len)
         }
         else if (eflag)
             emode = 1;
-        // UTF8であるかのチェック
+        // Check if it is UTF8
         if (!ufailed)
         {
             if (umode < 1)
@@ -267,7 +267,7 @@ charset_detect_buf(const unsigned char *buf, int len)
                 utf8 = 0;
         }
     }
-    // 最終的に一番得点の高いエンコードを返す
+    // Finally, return the encoding with the highest score
     if (euc > sjis && euc > utf8)
         return CHARSET_EUCJP;
     else if (!ufailed && utf8 > euc && utf8 > sjis)

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// main.c - migemoライブラリテストドライバ
+// main.c - Migemo library test driver
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
@@ -31,14 +31,14 @@ query_loop(migemo *p, int quiet)
 
         if (!quiet)
             printf("QUERY: ");
-        // gets()を使っていたがfgets()に変更
+        // Changed from gets() to fgets()
         if (!fgets(buf, sizeof(buf), stdin))
         {
             if (!quiet)
                 printf("\n");
             break;
         }
-        // 改行をNUL文字に置き換える
+        // Replace newline with NULL character
         if ((ans = strchr(buf, '\n')) != NULL)
             *ans = '\0';
 
@@ -154,7 +154,7 @@ main(int argc, char **argv)
     fplog = fopen("exe.log", "wt");
 #endif
 
-    // 辞書をカレントディレクトリと1つ上のディレクトリから捜す
+    // Search for dictionaries in the current directory and the parent directory
     if (!dict)
     {
         const char *found = NULL;
@@ -169,7 +169,7 @@ main(int argc, char **argv)
         if (!word && !mode_quiet)
             fprintf(fplog, "migemo_open(\"%s\")=%p\n", dict, pmigemo);
     }
-    // サブ辞書を読み込む
+    // Load sub-dictionaries
     if (subdict_count > 0)
     {
         int i;
@@ -224,7 +224,7 @@ main(int argc, char **argv)
             query_loop(pmigemo, mode_quiet);
         }
 #else
-        // プロファイル用
+        // For profiling
         {
             unsigned char *ans;
 

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -33,7 +33,7 @@
 # define EXPORTS
 #endif
 
-// migemoオブジェクト
+// Migemo object
 struct _migemo
 {
     int enable;
@@ -75,7 +75,8 @@ load_mtree_dictionary2(migemo *obj, const char *dict_file)
 {
     if (obj->charset == CHARSET_NONE)
     {
-        // 辞書の文字セットにあわせて正規表現生成時の関数を変更する
+        // Change the function used for regular expression generation to match
+        // the charset of the dictionary
         CHARSET_PROC_CHAR2INT char2int = NULL;
         CHARSET_PROC_INT2CHAR int2char = NULL;
         obj->charset = charset_detect_file(dict_file);
@@ -101,30 +102,30 @@ dircat(char *buf, const char *dir, const char *file)
 
 // migemo interfaces
 
-/// Migemoオブジェクトに辞書、またはデータファイルを追加読み込みする。
-/// dict_fileは読み込むファイル名を指定する。dict_idは読み込む辞書・データの
-/// 種類を指定するもので以下のうちどれか一つを指定する:
+/// Add a dictionary or a data file to the Migemo object.
+/// dict_file specifies the file name to load. dict_id specifies the type of
+/// dictionary/data to load:
 ///
 /// <dl>
 /// <dt>MIGEMO_DICTID_MIGEMO</dt>
-/// <dd>mikgemo-dict辞書</dd>
+/// <dd>migemo-dict dictionary</dd>
 /// <dt>MIGEMO_DICTID_ROMA2HIRA</dt>
-/// <dd>ローマ字→平仮名変換表</dd>
+/// <dd>Romaji to Hiragana conversion table</dd>
 /// <dt>MIGEMO_DICTID_HIRA2KATA</dt>
-/// <dd>平仮名→カタカナ変換表</dd>
+/// <dd>Hiragana to Katakana conversion table</dd>
 /// <dt>MIGEMO_DICTID_HAN2ZEN</dt>
-/// <dd>半角→全角変換表</dd>
+/// <dd>Half-width to Full-width conversion table</dd>
 /// <dt>MIGEMO_DICTID_ZEN2HAN</dt>
-/// <dd>全角→半角変換表</dd>
+/// <dd>Full-width to Half-width conversion table</dd>
 /// </dl>
 ///
-/// 戻り値は実際に読み込んだ種類を示し、上記の他に読み込みに失敗したことを示す
-/// 次の価が返ることがある。
+/// The return value indicates the type actually loaded, or it may indicate that
+/// loading failed by returning the following value:
 ///
 /// <dl><dt>MIGEMO_DICTID_INVALID</dt></dl>
-/// @param obj Migemoオブジェクト
-/// @param dict_id 辞書ファイルの種類
-/// @param dict_file 辞書ファイルのパス
+/// @param obj Migemo object
+/// @param dict_id Type of dictionary file
+/// @param dict_file Path to the dictionary file
 EXPORTS int MIGEMO_CALLTYPE
 migemo_load(migemo *obj, int dict_id, const char *dict_file)
 {
@@ -133,7 +134,7 @@ migemo_load(migemo *obj, int dict_id, const char *dict_file)
 
     if (dict_id == MIGEMO_DICTID_MIGEMO)
     {
-        // migemo辞書読み込み
+        // Load migemo dictionary
         mtree_p mtree;
 
         if ((mtree = load_mtree_dictionary2(obj, dict_file)) == NULL)
@@ -149,19 +150,19 @@ migemo_load(migemo *obj, int dict_id, const char *dict_file)
         switch (dict_id)
         {
             case MIGEMO_DICTID_ROMA2HIRA:
-                // ローマ字辞書読み込み
+                // Load romaji dictionary
                 dict = obj->roma2hira;
                 break;
             case MIGEMO_DICTID_HIRA2KATA:
-                // カタカナ辞書読み込み
+                // Load katakana dictionary
                 dict = obj->hira2kata;
                 break;
             case MIGEMO_DICTID_HAN2ZEN:
-                // 半角→全角辞書読み込み
+                // Load half-width to full-width dictionary
                 dict = obj->han2zen;
                 break;
             case MIGEMO_DICTID_ZEN2HAN:
-                // 半角→全角辞書読み込み
+                // Load half-width to full-width dictionary
                 dict = obj->zen2han;
                 break;
             default:
@@ -175,31 +176,34 @@ migemo_load(migemo *obj, int dict_id, const char *dict_file)
     }
 }
 
-/// Migemoオブジェクトを作成する。作成に成功するとオブジェクトが戻り値として
-/// 返り、失敗するとNULLが返る。dictで指定したファイルがmigemo-dict辞書として
-/// オブジェクト作成時に読み込まれる。辞書と同じディレクトリに:
+/// Create a Migemo object. If successful, the object is returned as the return
+/// value, and if it fails, NULL is returned. The file specified in dict is
+/// loaded as the migemo-dict dictionary during object creation. If the
+/// following files exist in the same directory as the dictionary:
 ///
 /// <dl>
 /// <dt>roma2hira.dat</dt>
-/// <dd>ローマ字→平仮名変換表 </dd>
+/// <dd>Romaji to Hiragana conversion table</dd>
 /// <dt>hira2kata.dat</dt>
-/// <dd>平仮名→カタカナ変換表 </dd>
+/// <dd>Hiragana to Katakana conversion table</dd>
 /// <dt>han2zen.dat</dt>
-/// <dd>半角→全角変換表 </dd>
+/// <dd>Half-width to full-width conversion table</dd>
 /// </dl>
 ///
-/// という名前のファイルが存在すれば、存在したものだけが読み込まれる。dictに
-/// NULLを指定した場合には、辞書を含めていかなるファイルも読み込まれない。
-/// ファイルはオブジェクト作成後にもmigemo_load()関数を使用することで追加読み
-/// 込みができる。
-/// @param dict migemo-dict辞書のパス。NULLの時は辞書を読み込まない。
-/// @returns 作成されたMigemoオブジェクト
+/// only the files that exist will be loaded. If NULL is specified for dict,
+/// no files, including the dictionary, will be loaded.
+/// Files can be additionally loaded after object creation using the
+/// migemo_load() function.
+///
+/// @param dict Path to the migemo-dict dictionary. If NULL, no dictionary is
+/// loaded.
+/// @returns The created Migemo object
 EXPORTS migemo *MIGEMO_CALLTYPE
 migemo_open(const char *dict)
 {
     migemo *obj;
 
-    // migemoオブジェクトと各メンバを構築
+    // Construct the Migemo object and its members
     if (!(obj = (migemo *)calloc(1, sizeof(migemo))))
         return obj;
     obj->enable = 0;
@@ -217,11 +221,12 @@ migemo_open(const char *dict)
         return obj = NULL;
     }
 
-    // デフォルトmigemo辞書が指定されていたらローマ字とカタカナ辞書も探す
+    // If a default migemo dictionary is specified, also look for romaji and
+    // katakana dictionaries
     if (dict)
     {
 #ifndef _MAX_PATH
-# define _MAX_PATH 1024 // いい加減な数値
+# define _MAX_PATH 1024 // Placeholder value
 #endif
         char dir[_MAX_PATH];
         char roma_dict[_MAX_PATH];
@@ -252,8 +257,8 @@ migemo_open(const char *dict)
     return obj;
 }
 
-/// Migemoオブジェクトを破棄し、使用していたリソースを解放する。
-/// @param obj 破棄するMigemoオブジェクト
+/// Destroy the Migemo object and release used resources.
+/// @param obj Migemo object to destroy
 EXPORTS void MIGEMO_CALLTYPE
 migemo_close(migemo *obj)
 {
@@ -314,35 +319,34 @@ add_mnode_query(migemo *object, unsigned char *query)
     }
 }
 
-/// 入力をローマから仮名に変換して検索キーに加える。
+/// Convert input from Romaji to Kana and add it to the search keys.
 static int
 add_roma(migemo *object, unsigned char *query)
 {
     unsigned char *stop, *hira, *kata, *han;
-
     hira = romaji_convert(object->roma2hira, query, &stop);
     if (!stop)
     {
         migemo_addword(object, hira);
-        // 平仮名による辞書引き
+        // Dictionary lookup using Hiragana
         add_mnode_query(object, hira);
-        // 片仮名文字列を生成し候補に加える
+        // Generate Katakana string and add to candidates
         kata = romaji_convert2(object->hira2kata, hira, NULL, 0);
         migemo_addword(object, kata);
-        // 半角カナを生成し候補に加える
+        // Generate half-width Katakana and add to candidates
         han = romaji_convert2(object->zen2han, kata, NULL, 0);
         migemo_addword(object, han);
         romaji_release(object->zen2han, han);
-        // カタカナによる辞書引き
+        // Dictionary lookup using Katakana
         add_mnode_query(object, kata);
-        romaji_release(object->hira2kata, kata); // カタカナ解放
+        romaji_release(object->hira2kata, kata); // Release Katakana
     }
-    romaji_release(object->roma2hira, hira); // 平仮名解放
+    romaji_release(object->roma2hira, hira); // Release Hiragana
 
     return stop ? 1 : 0;
 }
 
-/// ローマ字の末尾に母音を付け加えて、各々を検索キーに加える。
+/// Add vowels to the end of Romaji and add each to the search keys.
 static void
 add_dubious_vowels(migemo *object, unsigned char *buf, int index)
 {
@@ -354,8 +358,8 @@ add_dubious_vowels(migemo *object, unsigned char *buf, int index)
     }
 }
 
-// ローマ字変換が不完全だった時に、[aiueo]および"xn"と"xtu"を補って変換して
-// みる。
+// If Romaji conversion is incomplete, try adding [aiueo], "xn", and "xtu" to
+// the conversion.
 static void
 add_dubious_roma(migemo *object, rxgen *rx, unsigned char *query)
 {
@@ -365,8 +369,8 @@ add_dubious_roma(migemo *object, rxgen *rx, unsigned char *query)
 
     if (!(len = my_strlen(query)))
         return;
-    // ローマ字の末尾のアレンジのためのバッファを確保する。
-    //	    内訳: オリジナルの長さ、NUL、吃音(xtu)、補足母音([aieuo])
+    // Allocate a buffer for Romaji end arrangement. Details: original length,
+    // NUL, euphonic sounds (xtu), additional vowels ([aieuo])
     max = len + 1 + 3 + 1;
     buf = malloc(max);
     if (buf == NULL)
@@ -377,18 +381,20 @@ add_dubious_roma(migemo *object, rxgen *rx, unsigned char *query)
     if (!strchr(VOWEL_CHARS, buf[len - 1]))
     {
         add_dubious_vowels(object, buf, len);
-        // 未確定単語の長さが2未満か、未確定文字の直前が母音ならば…
+        // If the length of the unconfirmed word is less than 2 or the character
+        // before the unconfirmed character is a vowel...
         if (len < 2 || strchr(VOWEL_CHARS, buf[len - 2]))
         {
             if (buf[len - 1] == 'n')
             {
-                // 「ん」を補ってみる
+                // Try adding "n" (represented as "xn")
                 memcpy(&buf[len - 1], "xn", 2);
                 add_roma(object, buf);
             }
             else
             {
-                // 「っ{元の子音}{母音}」を補ってみる
+                // Try adding "っ{original consonant}{vowel}" (represented as
+                // "xtu")
                 buf[len + 2] = buf[len - 1];
                 memcpy(&buf[len - 1], "xtu", 3);
                 add_dubious_vowels(object, buf, len + 3);
@@ -399,8 +405,9 @@ add_dubious_roma(migemo *object, rxgen *rx, unsigned char *query)
     free(buf);
 }
 
-// queryを文節に分解する。文節の切れ目は通常アルファベットの大文字。文節が複
-// 数文字の大文字で始まった文節は非大文字を区切りとする。
+/// Split the query into phrases. Phrases are typically separated by uppercase
+/// letters. A phrase starting with multiple uppercase letters is separated by
+/// non-uppercase characters.
 static wordlist_p
 parse_query(migemo *object, const unsigned char *query)
 {
@@ -428,7 +435,7 @@ parse_query(migemo *object, const unsigned char *query)
             curr += len;
             sum += len;
         }
-        // 文節を登録する
+        // Register a phrase
         if (start && start < curr)
         {
             *pp = wordlist_open_len(start, sum);
@@ -440,7 +447,7 @@ parse_query(migemo *object, const unsigned char *query)
     return querylist;
 }
 
-// 1つの単語をmigemo変換。引数のチェックは行なわない。
+// Convert a single word using migemo. Does not perform argument checking.
 static int
 query_a_word(migemo *object, unsigned char *query)
 {
@@ -449,9 +456,9 @@ query_a_word(migemo *object, unsigned char *query)
     unsigned char *lower;
     int len = my_strlen(query);
 
-    // query自信はもちろん候補に加える
+    // Naturally, add the query itself to the candidates
     migemo_addword(object, query);
-    // queryそのものでの辞書引き
+    // Dictionary lookup with the query itself
     lower = malloc(len + 1);
     if (!lower)
         add_mnode_query(object, query);
@@ -459,7 +466,7 @@ query_a_word(migemo *object, unsigned char *query)
     {
         int i = 0, step;
 
-        // MBを考慮した大文字→小文字変換
+        // Uppercase to lowercase conversion considering multi-byte characters
         while (i <= len)
         {
             if (!object->char2int
@@ -475,7 +482,7 @@ query_a_word(migemo *object, unsigned char *query)
         free(lower);
     }
 
-    // queryを全角にして候補に加える
+    // Convert query to full-width and add to candidates
     zen = romaji_convert2(object->han2zen, query, NULL, 0);
     if (zen != NULL)
     {
@@ -483,7 +490,7 @@ query_a_word(migemo *object, unsigned char *query)
         romaji_release(object->han2zen, zen);
     }
 
-    // queryを半角にして候補に加える
+    // Convert query to half-width and add to candidates
     han = romaji_convert2(object->zen2han, query, NULL, 0);
     if (han != NULL)
     {
@@ -491,19 +498,19 @@ query_a_word(migemo *object, unsigned char *query)
         romaji_release(object->zen2han, han);
     }
 
-    // 平仮名、カタカナ、及びそれによる辞書引き追加
+    // Add Hiragana, Katakana, and dictionary lookups using them
     if (add_roma(object, query))
         add_dubious_roma(object, object->rx, query);
 
     return 1;
 }
 
-/// queryで与えられた文字列(ローマ字)を日本語検索のための正規表現へ変換する。
-/// 戻り値は変換された結果の文字列(正規表現)で、使用後は#migemo_release()関数
-/// へ渡すことで解放しなければならない。
-/// @param object Migemoオブジェクト
-/// @param query 問い合わせ文字列
-/// @returns 正規表現文字列。#migemo_release() で解放する必要有り。
+/// Converts the given string (Romaji) into a regular expression for Japanese
+/// search. The return value is the converted result (regular expression), which
+/// must be released using the #migemo_release() function.
+/// @param object Migemo object
+/// @param query Query string
+/// @returns Regular expression string. Must be released with #migemo_release().
 EXPORTS unsigned char *MIGEMO_CALLTYPE
 migemo_query(migemo *object, const unsigned char *query)
 {
@@ -517,12 +524,14 @@ migemo_query(migemo *object, const unsigned char *query)
 
         querylist = parse_query(object, query);
         if (querylist == NULL)
-            goto MIGEMO_QUERY_END; // 空queryのためエラー
+            goto MIGEMO_QUERY_END; // Error due to empty query
         outbuf = wordbuf_open();
         if (outbuf == NULL)
-            goto MIGEMO_QUERY_END; // 出力用のメモリ領域不足のためエラー
+            goto MIGEMO_QUERY_END; // Error due to insufficient memory for
+                                   // output
 
-        // 単語群をrxgenオブジェクトに入力し正規表現を得る
+        // Input word groups into the rxgen object and obtain a regular
+        // expression
         rxgen_reset(object->rx);
         for (p = querylist; p; p = p->next)
         {
@@ -530,7 +539,7 @@ migemo_query(migemo *object, const unsigned char *query)
 
             // printf("query=%s\n", p->ptr);
             query_a_word(object, p->ptr);
-            // 検索パターン(正規表現)生成
+            // Generate search pattern (regular expression)
             answer = rxgen_generate(object->rx);
             rxgen_reset(object->rx);
             wordbuf_cat(outbuf, answer);
@@ -551,45 +560,49 @@ MIGEMO_QUERY_END:
     return retval;
 }
 
-/// 使い終わったmigemo_query()関数で得られた正規表現を解放する。
-/// @param p Migemoオブジェクト
-/// @param string 正規表現文字列
+/// Frees the regular expression obtained with the migemo_query() function after
+/// use.
+/// @param p Migemo object
+/// @param string Regular expression string
 EXPORTS void MIGEMO_CALLTYPE
 migemo_release(migemo *p, unsigned char *string)
 {
     free(string);
 }
 
-/// Migemoオブジェクトが生成する正規表現に使用するメタ文字(演算子)を指定す
-/// る。indexでどのメタ文字かを指定し、opで置き換える。indexには以下の値が指
-/// 定可能である:
+/// Specifies the metacharacters (operators) used in the regular expression
+/// generated by the Migemo object. The index parameter specifies which
+/// metacharacter to replace with op. The following values can be specified:
 ///
 /// <dl>
 /// <dt>MIGEMO_OPINDEX_OR</dt>
-/// <dd>論理和。デフォルトは "|" 。vimで利用する際は "\|" 。</dd>
+/// <dd>Logical OR. Default is "|". When using in vim, use "\|".</dd>
 /// <dt>MIGEMO_OPINDEX_NEST_IN</dt>
-/// <dd>グルーピングに用いる開き括弧。デフォルトは "(" 。vimではレジスタ
-/// \\1～\\9に記憶させないようにするために "\%(" を用いる。Perlでも同様の
-/// ことを目論むならば "(?:" が使用可能。</dd>
+/// <dd>Opening parenthesis used for grouping. Default is "(". In vim, use "\%("
+/// to avoid saving it in registers \\1 to \\9. In Perl, you can use "(?:" to
+/// achieve the same thing.</dd>
 /// <dt>MIGEMO_OPINDEX_NEST_OUT</dt>
-/// <dd>グルーピングの終了を表す閉じ括弧。デフォルトでは ")" 。vimでは
-/// "\)" 。</dd>
+/// <dd>Closing parenthesis representing the end of a group. Default is ")". In
+/// vim, use "\)".</dd>
 /// <dt>MIGEMO_OPINDEX_SELECT_IN</dt>
-/// <dd>選択の開始を表す開き角括弧。デフォルトでは "[" 。</dd>
+/// <dd>Opening square bracket representing the start of a selection. Default
+/// is "[".</dd>
 /// <dt>MIGEMO_OPINDEX_SELECT_OUT</dt>
-/// <dd>選択の終了を表す閉じ角括弧。デフォルトでは "]" 。</dd>
+/// <dd>Closing square bracket representing the end of a selection. Default is
+/// "]".</dd>
 /// <dt>MIGEMO_OPINDEX_NEWLINE</dt>
-/// <dd>各文字の間に挿入される「0個以上の空白もしくは改行にマッチする」
-/// パターン。デフォルトでは "" であり設定されない。vimでは "\_s*" を指
-/// 定する。</dd>
+/// <dd>A pattern that matches zero or more whitespace or newline characters,
+/// inserted between each character.  Default is "", meaning no pattern is set.
+/// In vim, it refers to "\_s*".</dd>
 /// </dl>
 ///
-/// デフォルトのメタ文字は特に断りがない限りPerlのそれと同じ意味である。設定
-/// に成功すると戻り値は1(0以外)となり、失敗すると0になる。
-/// @param object Migemoオブジェクト
-/// @param index メタ文字識別子
-/// @param op メタ文字文字列
-/// @returns 成功時0以外、失敗時0。
+/// The default metacharacters have the same meaning as Perl's unless otherwise
+/// specified. A successful operation returns non-zero (1), and a failure
+/// returns 0.
+/// @param object Migemo object
+/// @param index Metacharacter identifier
+/// @param op Metacharacter string
+/// @returns Non-zero on success, 0 on failure.
 EXPORTS int MIGEMO_CALLTYPE
 migemo_set_operator(migemo *object, int index, const unsigned char *op)
 {
@@ -602,23 +615,24 @@ migemo_set_operator(migemo *object, int index, const unsigned char *op)
         return 0;
 }
 
-/// Migemoオブジェクトが生成する正規表現に使用しているメタ文字(演算子)を取得
-/// する。indexについてはmigemo_set_operator()関数を参照。戻り値にはindexの指
-/// 定が正しければメタ文字を格納した文字列へのポインタが、不正であればNULLが
-/// 返る。
-/// @param object Migemoオブジェクト
-/// @param index メタ文字識別子
-/// @returns 現在のメタ文字文字列
+/// Retrieves the metacharacters (operators) used in the regular expression
+/// generated by the Migemo object. For details about index, see the
+/// migemo_set_operator() function. If the index is valid, a pointer to the
+/// string containing the metacharacter is returned; otherwise, NULL is
+/// returned.
+/// @param object Migemo object
+/// @param index Metacharacter identifier
+/// @returns Current metacharacter string
 EXPORTS const unsigned char *MIGEMO_CALLTYPE
 migemo_get_operator(migemo *object, int index)
 {
     return object ? rxgen_get_operator(object->rx, index) : NULL;
 }
 
-/// Migemoオブジェクトにコード変換用のプロシージャを設定する。プロシージャに
-/// ついての詳細は「型リファレンス」セクションのMIGEMO_PROC_CHAR2INTを参照。
-/// @param object Migemoオブジェクト
-/// @param proc コード変換用プロシージャ
+/// Sets a procedure for code conversion in the Migemo object. For details about
+/// the procedure, see MIGEMO_PROC_CHAR2INT in the "Type Reference" section.
+/// @param object Migemo object
+/// @param proc Code conversion procedure
 EXPORTS void MIGEMO_CALLTYPE
 migemo_setproc_char2int(migemo *object, MIGEMO_PROC_CHAR2INT proc)
 {
@@ -626,10 +640,10 @@ migemo_setproc_char2int(migemo *object, MIGEMO_PROC_CHAR2INT proc)
         rxgen_setproc_char2int(object->rx, (RXGEN_PROC_CHAR2INT)proc);
 }
 
-/// Migemoオブジェクトにコード変換用のプロシージャを設定する。プロシージャに
-/// ついての詳細は「型リファレンス」セクションのMIGEMO_PROC_INT2CHARを参照。
-/// @param object Migemoオブジェクト
-/// @param proc コード変換用プロシージャ
+/// Sets a procedure for code conversion in the Migemo object. For details about
+/// the procedure, see MIGEMO_PROC_INT2CHAR in the "Type Reference" section.
+/// @param object Migemo object
+/// @param proc Code conversion procedure
 EXPORTS void MIGEMO_CALLTYPE
 migemo_setproc_int2char(migemo *object, MIGEMO_PROC_INT2CHAR proc)
 {
@@ -637,11 +651,11 @@ migemo_setproc_int2char(migemo *object, MIGEMO_PROC_INT2CHAR proc)
         rxgen_setproc_int2char(object->rx, (RXGEN_PROC_INT2CHAR)proc);
 }
 
-/// Migemoオブジェクトにmigemo_dictが読み込めているかをチェックする。有効な
-/// migemo_dictを読み込めて内部に変換テーブルが構築できていれば0以外(TRUE)
-/// を、構築できていないときには0(FALSE)を返す。
-/// @param obj Migemoオブジェクト
-/// @returns 成功時0以外、失敗時0。
+/// Checks whether the migemo_dict has been loaded into the Migemo object.
+/// Returns non-zero (TRUE) if a valid migemo_dict is loaded and conversion
+/// tables are built, and 0 (FALSE) otherwise.
+/// @param obj Migemo object
+/// @returns Non-zero on success, 0 on failure.
 EXPORTS int MIGEMO_CALLTYPE
 migemo_is_enable(migemo *obj)
 {
@@ -649,7 +663,7 @@ migemo_is_enable(migemo *obj)
 }
 
 #if 1
-// 主にデバッグ用の隠し関数
+// Primarily a hidden function for debugging purposes
 EXPORTS void MIGEMO_CALLTYPE
 migemo_print(migemo *object)
 {

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -220,7 +220,7 @@ mnode_close(mtree_p mtree)
 INLINE static mnode *
 search_or_new_mnode(mtree_p mtree, wordbuf_p buf)
 {
-    // ラベル単語が決定したら検索木に追加
+    // Add to the search tree once the label word is determined
     int ch;
     unsigned char *word;
     mnode **ppnext;
@@ -261,7 +261,7 @@ search_or_new_mnode(mtree_p mtree, wordbuf_p buf)
     return *res;
 }
 
-// 既存のノードにファイルからデータをまとめて追加する。
+// Batch add data from a file to existing nodes.
 mtree_p
 mnode_load(mtree_p mtree, FILE *fp)
 {
@@ -271,7 +271,7 @@ mnode_load(mtree_p mtree, FILE *fp)
     wordbuf_p buf;
     wordbuf_p prevlabel;
     wordlist_p *ppword = NULL; // To suppress warning for GCC
-    // 読み込みバッファ用変数
+    // Variables for the input buffer
     unsigned char cache[MNODE_BUFSIZE];
     unsigned char *cache_ptr = cache;
     unsigned char *cache_tail = cache;
@@ -284,9 +284,10 @@ mnode_load(mtree_p mtree, FILE *fp)
         goto END_MNODE_LOAD;
     }
 
-    // EOFの処理が曖昧。不正な形式のファイルが入った場合を考慮していない。各
-    // モードからEOFの道を用意しないと正しくないが…面倒なのでやらない。デー
-    // タファイルは絶対に間違っていないという前提を置く。
+    // EOF handling is ambiguous and doesn't account for malformed files. While
+    // it wouldn't be correct without providing a path to EOF from each mode,
+    // it's omitted for simplicity. We assume the data file is always
+    // well-formed.
     do
     {
         if (cache_ptr >= cache_tail)
@@ -299,29 +300,29 @@ mnode_load(mtree_p mtree, FILE *fp)
             ch = *cache_ptr;
         ++cache_ptr;
 
-        // 状態:modeのオートマトン
+        // Automaton for state 'mode'
         switch (mode)
         {
-            case 0: // ラベル単語検索モード
-                // 空白はラベル単語になりえません
+            case 0: // Label word search mode
+                // Whitespace cannot be a label word
                 if (isspace(ch) || ch == EOF)
                     continue;
-                // コメントラインチェック
+                // Check for comment line
                 else if (ch == ';')
                 {
-                    mode = 2; // 行末まで食い潰すモード へ移行
+                    mode = 2; // Switch to mode that consumes until end of line
                     continue;
                 }
                 else
                 {
-                    mode = 1; // ラベル単語の読込モード へ移行
+                    mode = 1; // Switch to mode for reading label words
                     wordbuf_reset(buf);
                     wordbuf_add(buf, (unsigned char)ch);
                 }
                 break;
 
-            case 1: // ラベル単語の読込モード
-                // ラベルの終了を検出
+            case 1: // Label word loading mode
+                // Detect end of label
                 switch (ch)
                 {
                     default:
@@ -335,44 +336,46 @@ mnode_load(mtree_p mtree, FILE *fp)
                             goto END_MNODE_LOAD;
                         }
                         wordbuf_reset(buf);
-                        mode = 3; // 単語前空白読飛ばしモード へ移行
+                        mode = 3; // Switch to mode for skipping whitespace
+                                  // before words
                         break;
                 }
                 break;
 
-            case 2: // 行末まで食い潰すモード
+            case 2: // Mode that consumes until end of line
                 if (ch == '\n')
                 {
                     wordbuf_reset(buf);
-                    mode = 0; // ラベル単語検索モード へ戻る
+                    mode = 0; // Return to label word search mode
                 }
                 break;
 
-            case 3: // 単語前空白読み飛ばしモード
+            case 3: // Mode for skipping whitespace before words
                 if (ch == '\n')
                 {
                     wordbuf_reset(buf);
-                    mode = 0; // ラベル単語検索モード へ戻る
+                    mode = 0; // Return to label word search mode
                 }
                 else if (ch != '\t')
                 {
-                    // 単語バッファリセット
+                    // Reset word buffer
                     wordbuf_reset(buf);
                     wordbuf_add(buf, (unsigned char)ch);
-                    // 単語リストの最後を検索(同一ラベルが複数時)
+                    // Search for the end of the word list (if multiple words
+                    // for same label)
                     ppword = &pp->list;
                     while (*ppword)
                         ppword = &(*ppword)->next;
-                    mode = 4; // 単語の読み込みモード へ移行
+                    mode = 4; // Switch to mode for reading words
                 }
                 break;
 
-            case 4: // 単語の読み込みモード
+            case 4: // Mode for reading words
                 switch (ch)
                 {
                     case '\t':
                     case '\n':
-                        // 単語を記憶
+                        // Store word
                         *ppword = wordlist_open_len(
                                 WORDBUF_GET(buf), WORDBUF_LEN(buf));
                         wordbuf_reset(buf);
@@ -380,12 +383,13 @@ mnode_load(mtree_p mtree, FILE *fp)
                         if (ch == '\t')
                         {
                             ppword = &(*ppword)->next;
-                            mode = 3; // 単語前空白読み飛ばしモード へ戻る
+                            mode = 3; // Return to mode for skipping whitespace
+                                      // before words
                         }
                         else
                         {
                             ppword = NULL;
-                            mode = 0; // ラベル単語検索モード へ戻る
+                            mode = 0; // Return to label word search mode
                         }
                         break;
                     default:

--- a/src/mnode.h
+++ b/src/mnode.h
@@ -9,7 +9,7 @@
 
 #include "wordlist.h"
 
-// ツリーオブジェクト
+// Tree object
 typedef struct _mnode mnode;
 struct _mnode
 {
@@ -41,7 +41,7 @@ void mnode_close(mtree_p p);
 mnode *mnode_query(mtree_p node, const unsigned char *query);
 void mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void *data);
 
-// 主にデバッグ用途
+// Mainly for debugging purposes
 void mnode_print(mtree_p mtree, unsigned char *p);
 
 #ifdef __cplusplus

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -1,6 +1,6 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// romaji.c - ローマ字変換
+// romaji.c - Romaji conversion
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
@@ -108,11 +108,11 @@ romanode_dig(romanode **ref_node, const unsigned char *key)
     return ref_node;
 }
 
-/// キーに対応したromanodeを検索して返す。
-/// @return romanodeが見つからなかった場合NULL
-/// @param node ルートノード
-/// @param key 検索キー
-/// @param skip 進めるべきkeyのバイト数を受け取るポインタ
+/// Search for and return the romanode corresponding to the key.
+/// @return NULL if romanode is not found
+/// @param node root node
+/// @param key search key
+/// @param skip pointer to receive the number of bytes to skip in key
 static romanode *
 romanode_query(romanode *node, const unsigned char *key, int *skip,
         ROMAJI_PROC_CHAR2INT char2int)
@@ -144,10 +144,11 @@ romanode_query(romanode *node, const unsigned char *key, int *skip,
                 }
                 node = node->child;
             }
-            // 次に走査するノードが空の場合、キーを進めてNULLを返す
+            // If the next node to traverse is empty, advance the key and return
+            // NULL
             if (!node)
             {
-                // 1バイトではなく1文字進める
+                // Advance by one character, not one byte
                 if (!char2int || (nskip = (*char2int)(key_start, NULL)) < 1)
                     nskip = 1;
                 // printf("  HERE 3: nskip=%d\n", nskip);
@@ -161,7 +162,7 @@ romanode_query(romanode *node, const unsigned char *key, int *skip,
     return node;
 }
 
-#if 0 // 未使用のため
+#if 0 // Unused
     static void
 romanode_print_stub(romanode* node, unsigned char* p)
 {
@@ -251,7 +252,7 @@ romaji_add_table(
             printf("romaji_add_table(\"%s\", \"%s\")\n", key, value););
     (*ref_node)->value = STRDUP(value);
 
-    // 「ん」と「っ」は保存しておく
+    // Save "n" ("ん") and "tsu" ("っ")
     if (object->fixvalue_xn == NULL && value_length > 0
             && !strcmp(key, ROMAJI_FIXKEY_XN))
     {
@@ -291,15 +292,17 @@ romaji_load_stub(romaji *object, FILE *fp)
         switch (mode)
         {
             case 0:
-                // key待ちモード
+                // Waiting for key mode
                 if (ch == '#')
                 {
-                    // 1文字先読みして空白ならばkeyとして扱う
+                    // If the next character is whitespace, treat it as part of
+                    // the key
                     ch = fgetc(fp);
                     if (ch != '#')
                     {
                         ungetc(ch, fp);
-                        mode = 1; // 行末まで読み飛ばしモード へ移行
+                        mode = 1; // Transition to skipping until end of line
+                                  // mode
                         break;
                     }
                 }
@@ -307,36 +310,36 @@ romaji_load_stub(romaji *object, FILE *fp)
                 {
                     wordbuf_reset(buf_key);
                     wordbuf_add(buf_key, (unsigned char)ch);
-                    mode = 2; // key読み込みモード へ移行
+                    mode = 2; // Transition to key reading mode
                 }
                 break;
 
             case 1:
-                // 行末まで読み飛ばしモード
+                // Skipping until end of line mode
                 if (ch == '\n')
-                    mode = 0; // key待ちモード へ移行
+                    mode = 0; // Transition to waiting for key mode
                 break;
 
             case 2:
-                // key読み込みモード
+                // Key reading mode
                 if (!isspace(ch))
                     wordbuf_add(buf_key, (unsigned char)ch);
                 else
-                    mode = 3; // value待ちモード へ移行
+                    mode = 3; // Transition to waiting for value mode
                 break;
 
             case 3:
-                // value待ちモード
+                // Waiting for value mode
                 if (ch != EOF && !isspace(ch))
                 {
                     wordbuf_reset(buf_value);
                     wordbuf_add(buf_value, (unsigned char)ch);
-                    mode = 4; // value読み込みモード へ移行
+                    mode = 4; // Transition to value reading mode
                 }
                 break;
 
             case 4:
-                // value読み込みモード
+                // Value reading mode
                 if (ch != EOF && !isspace(ch))
                     wordbuf_add(buf_value, (unsigned char)ch);
                 else
@@ -356,10 +359,10 @@ romaji_load_stub(romaji *object, FILE *fp)
     return 0;
 }
 
-/// ローマ字辞書を読み込む。
-/// @param object ローマ字オブジェクト
-/// @param filename 辞書ファイル名
-/// @return 成功した場合0、失敗した場合は非0を返す。
+/// Load the Romaji dictionary.
+/// @param object Romaji object
+/// @param filename Dictionary filename
+/// @return 0 on success, non-zero on failure.
 int
 romaji_load(romaji *object, const unsigned char *filename)
 {
@@ -407,7 +410,7 @@ romaji_convert2(romaji *object, const unsigned char *string,
             romanode *node;
             int skip;
 
-            // 「っ」の判定
+            // Detect "tsu" (small tsu: "っ")
             if (object->fixvalue_xtu && input[i] == input[i + 1]
                     && !strchr(ROMAJI_FIXKEY_NONXTU, input[i]))
             {
@@ -433,7 +436,7 @@ romaji_convert2(romaji *object, const unsigned char *string,
             }
             else if (!node)
             {
-                // 「n(子音)」を「ん(子音)」に変換
+                // Convert "n + (consonant)" to "ん + (consant)"
                 if (skip == 1 && input[i] == ROMAJI_FIXKEY_N
                         && object->fixvalue_xn)
                 {

--- a/src/romaji.h
+++ b/src/romaji.h
@@ -1,6 +1,6 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// romaji.h - ローマ字変換
+// romaji.h - Romaji conversion
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -157,7 +157,7 @@ static int
 default_int2char(unsigned int in, unsigned char *out)
 {
     int len = 0;
-    // outは最低でも16バイトはある、という仮定を置く
+    // Assume that out has at least 16 bytes
     switch (in)
     {
         case '\\':
@@ -252,17 +252,17 @@ rxgen_add(rxgen *object, const unsigned char *word)
         unsigned int code;
         int len = rxgen_call_char2int(object, word, &code);
 
-        // 入力パターンが尽きたら終了
+        // Terminate if the input pattern is exhausted
         if (code == 0)
         {
             if (pnode)
                 pnode->wordtail = true;
             if (*ppnode)
             {
-                // 登録しようとしている単語よりも、長い単語が既に登録されている
-                // 場合は、長い方を破棄する。例:
-                //      赤ちゃん + 赤 -> 赤
-                //      国際便 + 国際 -> 国際
+                // If a longer word is already registered than the one being
+                // registered, discard the longer one. E.g.:
+                //      赤ちゃん + 赤   -> 赤
+                //      国際便   + 国際 -> 国際
                 *ppnode = NULL;
                 // FIXME: mark *ppnode here for future use when collecting
                 // statistical information or reusing reclaimed nodes.
@@ -279,13 +279,13 @@ rxgen_add(rxgen *object, const unsigned char *word)
 
         if (pnode && pnode->wordtail)
         {
-            // 登録しようとしている単語よりも短い単語が登録されている場合、
-            // それ以降の文字は破棄する。例:
-            //      赤 + 赤ちゃん -> 赤
-            //      国際 + 国際便 -> 国際
+            // If a shorter word is already registered than the one being
+            // registered, discard the remaining characters. E.g.:
+            //      赤ちゃん + 赤   -> 赤
+            //      国際便   + 国際 -> 国際
             return 2; // not registered a word, but found short one.
         }
-        // 子ノードを辿って深い方へ注視点を移動
+        // Move the focus deeper by traversing child nodes
     }
     return 1; // registered a word, some nodes.
 }
@@ -336,11 +336,11 @@ rxgen_write_node_has_children(
         rxgen_write_node_has_children(object, buf, node->low, needOr);
     if (node->child != NULL)
     {
-        // 必要ならばORを出力
+        // Output OR if necessary
         if (*needOr)
             wordbuf_cat(buf, object->op_or);
         rxgen_write_node_code(object, buf, node);
-        // 空白・改行飛ばしのパターンを挿入
+        // Insert a pattern that skips whitespace/newline
         if (object->op_newline[0])
             wordbuf_cat(buf, object->op_newline);
         rxgen_generate_stub(object, buf, node->child);
@@ -353,7 +353,8 @@ rxgen_write_node_has_children(
 static void
 rxgen_generate_stub(rxgen *object, wordbuf_t *buf, rnode *node)
 {
-    // 現在の階層の特性(兄弟の数、子供の数)をチェックする
+    // Check characteristics of the current level (number of siblings, number of
+    // children)
     int childrenCount = 0;
     int brotherCount = 1;
     rxgen_rnode_count(node, &childrenCount, &brotherCount);
@@ -366,11 +367,11 @@ rxgen_generate_stub(rxgen *object, wordbuf_t *buf, rnode *node)
     bool needGroup = brotherCount > 1 && childrenCount > 0;
     bool needClass = noChildrenCount > 1;
 
-    // 必要ならば()によるグルーピング
+    // Group using () if necessary
     if (needGroup)
         wordbuf_cat(buf, object->op_nest_in);
 
-    // 子の無いノードを先に[]によりグルーピング
+    // Group nodes without children first with []
     if (noChildrenCount > 0)
     {
         if (needClass)
@@ -383,14 +384,14 @@ rxgen_generate_stub(rxgen *object, wordbuf_t *buf, rnode *node)
             rxgen_write_node_no_children(object, buf, node);
     }
 
-    // 子のあるノードを出力
+    // Output nodes with children
     if (childrenCount > 0)
     {
         bool needOr = noChildrenCount > 0;
         rxgen_write_node_has_children(object, buf, node, &needOr);
     }
 
-    // 必要ならば()によるグルーピング
+    // Group using () if necessary
     if (needGroup)
         wordbuf_cat(buf, object->op_nest_out);
 }
@@ -510,7 +511,7 @@ rxgen_release(rxgen *object, unsigned char *string)
     free(string);
 }
 
-// rxgen_add()してきたパターンを全てリセット。
+// Reset all patterns added via rxgen_add()
 void
 rxgen_reset(rxgen *object)
 {

--- a/src/testdir/romaji_main.c
+++ b/src/testdir/romaji_main.c
@@ -35,7 +35,7 @@ query_one(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han,
     unsigned char *hira;
     unsigned char *zen;
     unsigned char *han;
-    // ローマ字→平仮名(表示)→片仮名(表示)
+    // Romaji -> Hiragana (display) -> Katakana (display)
     if ((hira = romaji_convert(object, buf, &stop)) != NULL)
     {
         unsigned char *kata;
@@ -78,7 +78,7 @@ query_loop(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
             printf("\n");
             break;
         }
-        // 改行をNUL文字に置き換える
+        // Replace newline with NUL character
         if ((ans = strchr(buf, '\n')) != NULL)
             *ans = '\0';
         query_one(object, hira2kata, han2zen, zen2han, buf);

--- a/src/wordbuf.c
+++ b/src/wordbuf.c
@@ -44,8 +44,8 @@ wordbuf_close(wordbuf_p p)
 }
 
 // wordbuf_extend(wordbuf_p p, int req_len);
-//	バッファの伸長。エラー時には0が帰る。
-//	高速化のために伸ばすべきかは呼出側で判断する。
+//	Expand the buffer. Returns 0 on error.
+//	The caller decides whether to expand for performance.
 int
 wordbuf_extend(wordbuf_p p, int req_len)
 {

--- a/src/wordbuf.h
+++ b/src/wordbuf.h
@@ -9,9 +9,9 @@
 typedef struct _wordbuf_t wordbuf_t, *wordbuf_p;
 struct _wordbuf_t
 {
-    int len; // bufに割り当てられているメモリ量
+    int len; // amount of memory allocated to buf
     unsigned char *buf;
-    int last; // bufに実際に格納している文字列の長さ
+    int last; // length of the string actually stored in buf
 };
 
 extern int n_wordbuf_open;

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -25,8 +25,9 @@ wordlist_open_len(const unsigned char *ptr, int len)
         {
             p->ptr = (char *)(p + 1);
             p->next = NULL;
-            // ほぼstrdup()と等価な実装。単語の保存に必要な総メモリを知りた
-            // いので独自に再実装。
+            // Implementation nearly equivalent to strdup(). Reimplemented
+            // manually because we need to know the total memory required to
+            // store the word.
             memcpy(p->ptr, ptr, len);
             p->ptr[len] = '\0';
 


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` to provide project structure, build instructions, coding standards, and dictionary generation guidance for developers and AI agents.
- Translate existing Japanese code comments into English for better international readability.

## Changes
- Add `AGENTS.md`
- Update comments in source files from Japanese to English