### PR TITLE
add common.h to support shared debug setup and CRT heap tracking

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #define BUFLEN_DETECT 4096
 
 #include <limits.h>

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,16 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
+// common.h - To inject shared code into all .c files, such as for debugging
+//            purposes.
+
+#pragma once
+
+// Example for heap debugging on Windows. You can enable it by changing the '0'
+// below to '1'.
+#if 0
+# if defined(_WIN32) && defined(_DEBUG)
+#  define _CRTDBG_MAP_ALLOC
+#  include <crtdbg.h>
+#  include <stdlib.h>
+# endif
+#endif

--- a/src/filename.c
+++ b/src/filename.c
@@ -4,6 +4,8 @@
 //
 // Written by:  Muraoka Taro  <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <limits.h>
 #include <string.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <ctype.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -8,6 +8,14 @@ target_compile_definitions(
   romaji
   PRIVATE DICTDIR="${CMAKE_BINARY_DIR}/dict/utf-8" _DEBUG)
 
+if(MSVC)
+  set_target_properties(
+    romaji
+    PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDebug")
+elseif(MINGW)
+  target_link_libraries(romaji PRIVATE ucrtbased)
+endif()
+
 #------------------------------------------------------------------------------
 # qspeed: profiling tool
 add_executable(
@@ -25,6 +33,14 @@ target_include_directories(qspeed PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_compile_definitions(
   qspeed
   PRIVATE DICTDIR="${CMAKE_BINARY_DIR}/dict/utf-8" _DEBUG)
+
+if(MSVC)
+  set_target_properties(
+    qspeed
+    PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDebug")
+elseif(MINGW)
+  target_link_libraries(qspeed PRIVATE ucrtbased)
+endif()
 
 #------------------------------------------------------------------------------
 # Profiling target "profile": `cmake --build build --target profile`

--- a/src/testdir/profile_speed.c
+++ b/src/testdir/profile_speed.c
@@ -4,6 +4,8 @@
 //
 // Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #define NUM_TRIAL 10
 
 #include <stdio.h>

--- a/src/wordbuf.c
+++ b/src/wordbuf.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -4,6 +4,8 @@
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
+#include "common.h"
+
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- Introduce `src/common.h` and include it at the top of all C sources.
- Add commented-out CRT heap debugging configuration (`_CRTDBG_MAP_ALLOC`) as an opt-in toggle (`#if 0`).
- Link `ucrtbased` library for `romaji` and `qspeed` targets on MSVC/MinGW under debug builds.

## Details
This PR adds a common header infrastructure (`src/common.h`) to allow injecting shared definitions and debug hooks across all C source files without modifying individual logic.

The CRT heap tracking configuration is disabled by default (`#if 0`), ensuring no impact on production or release builds while making future memory leak debugging on Windows straight-forward.