### PR TITLE
wordbuf: Use size_t for buffer length and offsets

### DIFF
--- a/src/wordbuf.c
+++ b/src/wordbuf.c
@@ -53,13 +53,13 @@ wordbuf_close(wordbuf *p)
 // wordbuf_extend(wordbuf * p, int req_len);
 //	Expand the buffer. Returns 0 on error.
 //	The caller decides whether to expand for performance.
-int
-wordbuf_extend(wordbuf *p, int req_len)
+size_t
+wordbuf_extend(wordbuf *p, size_t req_len)
 {
-    if (req_len > WORDBUF_MAX_SIZE || req_len < 0)
+    if (req_len > WORDBUF_MAX_SIZE)
         return 0;
 
-    int newlen = p->len * 2;
+    size_t newlen = p->len * 2;
     unsigned char *newbuf;
 
     while (req_len > newlen)
@@ -77,13 +77,13 @@ wordbuf_extend(wordbuf *p, int req_len)
     }
 }
 
-int
+size_t
 wordbuf_last(wordbuf *p)
 {
     return p->last;
 }
 
-int
+size_t
 wordbuf_cat(wordbuf *p, const unsigned char *sz)
 {
     size_t len = 0;
@@ -98,24 +98,24 @@ wordbuf_cat(wordbuf *p, const unsigned char *sz)
     {
         size_t newlen = (size_t)p->last + len + 1;
 
-        if (newlen > p->len && !wordbuf_extend(p, (int)newlen))
+        if (newlen > p->len && !wordbuf_extend(p, newlen))
             return 0;
         memcpy(&p->buf[p->last], sz, len + 1);
-        p->last = p->last + len;
+        p->last += len;
     }
     return p->last;
 }
 
-int
+size_t
 wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len)
 {
     if (p != NULL && len > 0)
     {
-        size_t newlen = buf->last + (int)len + 1;
-        if (newlen > buf->len && !wordbuf_extend(buf, (int)newlen))
+        size_t newlen = buf->last + len + 1;
+        if (newlen > buf->len && !wordbuf_extend(buf, newlen))
             return 0;
         memcpy(&buf->buf[buf->last], p, len);
-        buf->last = buf->last + (int)len;
+        buf->last += len;
         buf->buf[buf->last] = '\0';
     }
     return buf->last;

--- a/src/wordbuf.h
+++ b/src/wordbuf.h
@@ -9,8 +9,8 @@
 typedef struct wordbuf wordbuf;
 struct wordbuf
 {
-    int len;  // amount of memory allocated to buf
-    int last; // length of the string actually stored in buf
+    size_t len;  // amount of memory allocated to buf
+    size_t last; // length of the string actually stored in buf
     unsigned char *buf;
 };
 
@@ -27,10 +27,10 @@ extern "C" {
 
 wordbuf *wordbuf_open();
 void wordbuf_close(wordbuf *p);
-int wordbuf_extend(wordbuf *p, int len);
-int wordbuf_last(wordbuf *p);
-int wordbuf_cat(wordbuf *p, const unsigned char *sz);
-int wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len);
+size_t wordbuf_extend(wordbuf *p, size_t len);
+size_t wordbuf_last(wordbuf *p);
+size_t wordbuf_cat(wordbuf *p, const unsigned char *sz);
+size_t wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len);
 unsigned char *wordbuf_get(wordbuf *p);
 
 #ifdef __cplusplus
@@ -44,10 +44,10 @@ wordbuf_reset(wordbuf *p)
     p->buf[0] = '\0';
 }
 
-static inline int
+static inline size_t
 wordbuf_add(wordbuf *p, unsigned char ch)
 {
-    int newlen = p->last + 2;
+    size_t newlen = p->last + 2;
     if (newlen > p->len)
         if (!wordbuf_extend(p, newlen))
             return 0;


### PR DESCRIPTION
### Summary
Refactor `wordbuf` to use `size_t` instead of `int` for buffer lengths, offsets, and related function signatures.

### Key Changes
- Updated `struct wordbuf` members (`len`, `last`) to `size_t`.
- Updated function return types and parameters (`wordbuf_extend`, `wordbuf_last`, `wordbuf_cat`, `wordbuf_write_bytes`, `wordbuf_add`) to use `size_t`.
- Cleaned up redundant casts and unsafe bounds checks (e.g. `req_len < 0` for `size_t`).

### Reason
- Resolves MSVC conversion warning `C4267` ('=': conversion from 'size_t' to 'int', possible loss of data).
- Eliminates unnecessary narrowing conversions and improves type safety when handling larger buffers.