### PR TITLE
cmake: suppress MSVC inline expansion warnings C4710 and C4711

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 
 if(MSVC)
-  add_compile_options(/utf-8 /W3 /wd5045)
+  add_compile_options(/utf-8 /W3 /wd4710 /wd4711 /wd5045)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 


### PR DESCRIPTION
## Summary
Suppresses MSVC compiler warnings **C4710** (function not inlined) and **C4711** (function selected for automatic inline expansion) by adding `/wd4710` and `/wd4711` to `add_compile_options`.

## Motivation
These level 4 informational warnings are emitted during optimization and do not indicate code quality or correctness issues. Disabling them cleans up the build logs and reduces noise.

## Changes
- Updated `CMakeLists.txt` under `if(MSVC)` to pass `/wd4710` and `/wd4711`.