### PR TITLE
Use size_t for length and count variables to fix C4267

### DIFF
--- a/src/romaji.c
+++ b/src/romaji.c
@@ -437,7 +437,7 @@ romaji_convert2(romaji *object, const unsigned char *string,
             {
                 if (string[i])
                 {
-                    stop = WORDBUF_LEN(buf);
+                    stop = (int)WORDBUF_LEN(buf);
                     wordbuf_cat(buf, &string[i]);
                 }
                 break;

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -12,14 +12,14 @@
 
 #include "wordlist.h"
 
-int n_wordlist_open = 0;
-int n_wordlist_close = 0;
-int n_wordlist_total = 0;
+size_t n_wordlist_open = 0;
+size_t n_wordlist_close = 0;
+size_t n_wordlist_total = 0;
 
 wordlist *
-wordlist_new(const unsigned char *ptr, int len)
+wordlist_new(const unsigned char *ptr, size_t len)
 {
-    if (!ptr || len < 0)
+    if (!ptr)
         return NULL;
 
     wordlist *p = (wordlist *)malloc(sizeof(*p) + len + 1);
@@ -31,7 +31,8 @@ wordlist_new(const unsigned char *ptr, int len)
 
     // Implementation nearly equivalent to strdup(). Reimplemented manually
     // because we need to know the total memory required to store the word.
-    memcpy(p->ptr, ptr, len);
+    if (len > 0)
+        memcpy(p->ptr, ptr, len);
     p->ptr[len] = '\0';
 
     ++n_wordlist_open;

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -13,15 +13,15 @@ struct wordlist
     wordlist *next;
 };
 
-extern int n_wordlist_open;
-extern int n_wordlist_close;
-extern int n_wordlist_total;
+extern size_t n_wordlist_open;
+extern size_t n_wordlist_close;
+extern size_t n_wordlist_total;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-wordlist *wordlist_new(const unsigned char *ptr, int len);
+wordlist *wordlist_new(const unsigned char *ptr, size_t len);
 void wordlist_destroy(wordlist *p);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
This PR addresses MSVC compiler warning **C4267** (`conversion from 'size_t' to 'int', possible loss of data`) across several modules.

## Changes
- **`wordlist`**: Updated `wordlist_new()`'s `len` parameter and global counter variables (`n_wordlist_open`, `n_wordlist_close`, `n_wordlist_total`) from `int` to `size_t`.
- **`wordlist`**: Added a `len > 0` guard check before calling `memcpy()` in `wordlist_new()` for safe handling of empty buffers.
- **`romaji`**: Added an explicit `(int)` cast for `WORDBUF_LEN` in `romaji.c` to suppress the warning while safely maintaining negative index/sentinel checks.

## Impact
- Eliminates C4267 warnings during MSVC builds.
- Improves type safety and consistency when dealing with memory sizes and array bounds without breaking function behavior.