### PR TITLE
Balance dictionary arrays with DFS midpoint extraction for optimal TST performance

### DIFF
--- a/dict/optimize-dict.pl
+++ b/dict/optimize-dict.pl
@@ -1,13 +1,40 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 # vim:set ts=8 sts=4 sw=4 tw=0 et:
 #
 # optimize-dict.pl - Optimize migemo-dict to load by C/Migemo.
 #
 # Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-binmode STDOUT;
+use strict;
+use warnings;
+
+binmode STDOUT, ':utf8';
+binmode STDIN,  ':utf8';
+
 my %migemo;
 my @migemo;
+
+# Extract the midpoint from a sorted array using DFS and rearrange the
+# elements.
+sub balance_array {
+    my (@arr) = @_;
+    my @result;
+
+    my $dfs;
+    $dfs = sub {
+        my ($low, $high) = @_;
+        return if $low > $high;
+
+        my $mid = int(($low + $high) / 2);
+        push @result, $arr[$mid];
+
+        $dfs->($low, $mid - 1);
+        $dfs->($mid + 1, $high);
+    };
+
+    $dfs->(0, $#arr);
+    return @result;
+}
 
 # Read migemo-dict file.
 while (<>)
@@ -20,7 +47,7 @@ while (<>)
     push @{$migemo{$label}}, @word;
 }
 
-@migemo = sort {length($b) <=> length($a) or $a cmp $b} @migemo;
+@migemo = balance_array(sort {$a cmp $b} @migemo);
 
 # Write migemo-dict file.
 my $i;
@@ -29,7 +56,9 @@ for ($i = 0; $i < @migemo; ++$i)
     my $label = $migemo[$i];
     if (exists $migemo{$label})
     {
-        print "$label\t" . join("\t", &uniq_array($migemo{$label})) . "\n";
+        my @values = uniq_array($migemo{$label});
+        @values = balance_array(@values);
+        print "$label\t" . join("\t", @values) . "\n";
         delete $migemo{$label};
     }
 }
@@ -37,5 +66,5 @@ for ($i = 0; $i < @migemo; ++$i)
 sub uniq_array
 {
     my %array = map {$_, 1} @{$_[0]};
-    return keys %array
+    return sort keys %array
 }

--- a/dict/skk2migemo.pl
+++ b/dict/skk2migemo.pl
@@ -1,11 +1,16 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # vim:set ts=8 sts=4 sw=4 tw=0 et:
 #
 # conv.pl - Convert SKK-JISYO to migemo-dict
 #
 # Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
-binmode STDOUT;
+use strict;
+use warnings;
+
+binmode STDOUT, ':utf8';
+binmode STDIN,  ':utf8';
+
 while (<>)
 {
     chomp;
@@ -29,7 +34,7 @@ while (<>)
 
     $value =~ s{^/}{};
     $value =~ s{/$}{};
-    @values = grep {
+    my @values = grep {
         # Remove lisp expressions.
         $_ !~ m/^\([a-zA-Z].*\)$/;
     } grep {
@@ -38,11 +43,10 @@ while (<>)
     } map {
         # Remove annotation
         s/;.*$//; $_;
-    } split(/\//, $value);
+    } split(/\s*\/\s*/, $value);
 
     # Output
-    if ($key ne '' and $#values >= 0)
-    {
-        print "$key\t" . join("\t", @values) . "\n";
+    if ($key ne '' and @values) {
+        print "$key\t" . join("\t", sort @values) . "\n";
     }
 }


### PR DESCRIPTION
## Summary
Optimize dictionary key and value layouts using DFS midpoint extraction (`balance_array`) to construct highly balanced Ternary Search Trees (TST) while maintaining 100% build reproducibility, alongside modernizing Perl conversion scripts.

## Changes
- **Balance tree layouts:**
  - Rearrange sorted `@migemo` keys and `@values` candidates in `optimize-dict.pl` using DFS midpoint extraction (`balance_array`).
  - Significantly reduce TST depth (`Sibling Depth`) and lookup costs (`Compare Count`) for both `mnode` and `rnode`.
- **Ensure reproducible builds:**
  - Deterministically sort output candidates in `skk2migemo.pl` and `optimize-dict.pl` prior to balancing.
- **Modernize Perl scripts:**
  - Add `use strict` and `use warnings` with explicit variable declarations (`my`).
  - Set explicit UTF-8 I/O layers (`:utf8`) for `STDIN` and `STDOUT`.
  - Normalize shebangs to `#!/usr/bin/env perl` and fix script file permissions (executable).