### PR TITLE
Fix potential null pointer dereferences and duplicate assignment typo

### DIFF
--- a/src/mnode.c
+++ b/src/mnode.c
@@ -230,6 +230,9 @@ search_or_new_mnode(mtree *mt, wordbuf *buf)
     mnode *root;
 
     word = WORDBUF_GET(buf);
+    if (!word || *word == '\0')
+        return NULL;
+
     root = mt->used > 0 ? &mt->nodes[0] : NULL;
     ppnext = &root;
     while ((ch = *word) != 0)
@@ -260,6 +263,8 @@ search_or_new_mnode(mtree *mt, wordbuf *buf)
         ++word;
     }
 
+    if (!res)
+        return NULL;
     return *res;
 }
 
@@ -423,13 +428,17 @@ mnode_open(FILE *fp)
     mtree *mt;
 
     mt = (mtree *)calloc(1, sizeof(*mt));
+    if (!mt)
+        return NULL;
     mt->active = mt;
-    if (mt && fp)
+    if (fp)
+    {
         if (!mnode_load(mt, fp))
         {
             mnode_close(mt);
             return NULL;
         }
+    }
 
     return mt;
 }

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -263,8 +263,6 @@ search_or_new_mnode(mtree *mt, wordbuf *buf)
         ++word;
     }
 
-    if (!res)
-        return NULL;
     return *res;
 }
 
@@ -431,15 +429,13 @@ mnode_open(FILE *fp)
     if (!mt)
         return NULL;
     mt->active = mt;
-    if (fp)
+    if (!fp)
+        return mt;
+    if (!mnode_load(mt, fp))
     {
-        if (!mnode_load(mt, fp))
-        {
-            mnode_close(mt);
-            return NULL;
-        }
+        mnode_close(mt);
+        return NULL;
     }
-
     return mt;
 }
 

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -384,7 +384,7 @@ romaji_load(romaji *object, const unsigned char *filename)
 #endif
     if ((fp = fopen(filename, "rt")) != NULL)
     {
-        int result = result = romaji_load_stub(object, fp);
+        int result = romaji_load_stub(object, fp);
         fclose(fp);
         return result;
     }


### PR DESCRIPTION
This pull request fixes critical security and stability issues identified via static analysis in the mnode and romaji implementation. Specifically, it guards against null pointer dereferences on memory allocation failures and malformed inputs, and corrects a redundant self-assignment bug.

---
*PR created automatically by Jules for task [13616056633980370305](https://jules.google.com/task/13616056633980370305) started by @koron*