### PR TITLE
test: Pass dict directories from CMake via macros

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,14 @@
 add_executable(test1 main.c test1.c)
+
 target_link_libraries(test1 PRIVATE migemo)
+
 target_include_directories(test1 PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+target_compile_definitions(
+  test1
+  PRIVATE
+  TEST_DICTDIR_MIGEMO="${CMAKE_CURRENT_SOURCE_DIR}/test1"
+  TEST_DICTDIR_ROMA2HIRA="${CMAKE_SOURCE_DIR}/dict")
 
 #------------------------------------------------------------------------------
 

--- a/test/test1.c
+++ b/test/test1.c
@@ -5,6 +5,13 @@
 
 #include "migemo.h"
 
+#ifndef TEST_DICTDIR_MIGEMO
+# define TEST_DICTDIR_MIGEMO "test1"
+#endif
+#ifndef TEST_DICTDIR_ROMA2HIRA
+# define TEST_DICTDIR_ROMA2HIRA "../dict"
+#endif
+
 static int
 assert_query(migemo *p, const char *q, const char *ex)
 {
@@ -42,16 +49,18 @@ test1(void)
     int r;
     migemo *p;
 
-    p = migemo_open("test1/migemo-dict");
+    p = migemo_open(TEST_DICTDIR_MIGEMO "/migemo-dict");
     if (p == NULL)
     {
         printf("Failed: can't create migemo object and get its pointer\n");
         return 1;
     }
-    r = migemo_load(p, MIGEMO_DICTID_ROMA2HIRA, "../dict/roma2hira.dat");
+    r = migemo_load(p, MIGEMO_DICTID_ROMA2HIRA,
+            TEST_DICTDIR_ROMA2HIRA "/roma2hira.dat");
     if (r != MIGEMO_DICTID_ROMA2HIRA)
     {
-        printf("Failed: can't load \"../dict/roma2hira.dat (%d)\n",
+        printf("Failed: can't load \"%s\" (dict_id: %d)\n",
+                TEST_DICTDIR_ROMA2HIRA "/roma2hira.dat",
                 MIGEMO_DICTID_ROMA2HIRA);
         return r;
     }


### PR DESCRIPTION
## Overview
Replaced hardcoded relative paths for test dictionaries with preprocessor macros defined in CMake. This enables running tests cleanly in out-of-source builds (e.g., when building inside a separate `build/` directory).

## Changes
- **`test/CMakeLists.txt`**: Added `target_compile_definitions` to pass `TEST_DICTDIR_MIGEMO` and `TEST_DICTDIR_ROMA2HIRA` macros to `test1`.
- **`test/test1.c`**:
  - Added fallback `#ifndef` definitions to preserve backwards compatibility for non-CMake builds.
  - Replaced hardcoded dictionary paths with the newly introduced macros.
  - Updated error log formatting to output the dynamically resolved path upon failure.

## Testing
- Verified that tests pass in both in-source and out-of-source build setups.