### PR TITLE
refactor: consolidate trie statistics into unified module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
     mnode.c
     romaji.c
     rxgen.c
+    trie.c
     wordbuf.c
     wordlist.c)
 

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -15,6 +15,7 @@
 #include "charset.h"
 #include "filename.h"
 #include "migemo.h"
+#include "migemo_struct.h"
 #include "mnode.h"
 #include "romaji.h"
 #include "rxgen.h"
@@ -34,21 +35,6 @@
 #else
 # define EXPORTS
 #endif
-
-// Migemo object
-struct migemo
-{
-    int enable;
-    mtree *mtree;
-    int charset;
-    romaji *roma2hira;
-    romaji *hira2kata;
-    romaji *han2zen;
-    romaji *zen2han;
-    rxgen *rx;
-
-    CHARSET_PROC_CHAR2INT char2int;
-};
 
 static const unsigned char VOWEL_CHARS[] = "aiueo";
 

--- a/src/migemo_struct.h
+++ b/src/migemo_struct.h
@@ -1,0 +1,25 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
+// migemo_struct.h -
+
+#pragma once
+
+#include "charset.h"
+#include "mnode.h"
+#include "romaji.h"
+#include "rxgen.h"
+
+// Migemo object
+struct migemo
+{
+    int enable;
+    mtree *mtree;
+    int charset;
+    romaji *roma2hira;
+    romaji *hira2kata;
+    romaji *han2zen;
+    romaji *zen2han;
+    rxgen *rx;
+
+    CHARSET_PROC_CHAR2INT char2int;
+};

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -13,6 +13,7 @@
 
 #include "charset.h"
 #include "mnode.h"
+#include "trie.h"
 #include "wordbuf.h"
 #include "wordlist.h"
 
@@ -42,24 +43,9 @@ struct mtree
     CHARSET_PROC_INT2CHAR int2char;
 };
 
-typedef struct
-{
-    size_t total_nodes;
-    size_t low_count;
-    size_t high_count;
-    size_t child_count;
-    size_t word_count;
-
-    int max_sibling_depth;
-    size_t total_sibling_depth;
-
-    int max_word_cmp_count;
-    size_t total_word_cmp_count;
-} mnode_stat;
-
 static void
 mnode_debug_stat_stub(
-        mnode *node, mnode_stat *stat, int sib_depth, int total_cmp)
+        mnode *node, trie_stat *stat, int sib_depth, int total_cmp)
 {
     if (!node)
         return;
@@ -78,10 +64,10 @@ mnode_debug_stat_stub(
 
     if (node->list)
     {
-        stat->word_count++;
-        stat->total_word_cmp_count += total_cmp;
-        if (total_cmp > stat->max_word_cmp_count)
-            stat->max_word_cmp_count = total_cmp;
+        stat->wordtail_count++;
+        stat->total_node_cmp_count += total_cmp;
+        if (total_cmp > stat->max_node_cmp_count)
+            stat->max_node_cmp_count = total_cmp;
     }
 
     // recursive calls for low, high, and child nodes.
@@ -94,7 +80,7 @@ mnode_debug_stat_stub(
 }
 
 static void
-mnode_debug_stat(mnode *root, mnode_stat *stat)
+mnode_debug_stat(mnode *root, trie_stat *stat)
 {
     if (!stat)
         return;
@@ -113,35 +99,10 @@ mnode_print_stat(mtree *mt)
         return;
     }
 
-    mnode_stat v, *stat = &v;
-    mnode_debug_stat(mt->rootnode, stat);
+    trie_stat stat;
+    mnode_debug_stat(mt->rootnode, &stat);
 
-    printf("=== mnode statistics ===\n");
-    printf("Total Nodes          : %zu\n", stat->total_nodes);
-    printf("Word Nodes (list)    : %zu\n", stat->word_count);
-    printf("Pointer Counts       : low=%zu, high=%zu, child=%zu\n",
-            stat->low_count, stat->high_count, stat->child_count);
-    printf("Low/High Balance Ratio: %.2f%% / %.2f%%\n",
-            stat->low_count + stat->high_count > 0
-                    ? (double)stat->low_count
-                              / (stat->low_count + stat->high_count) * 100.0
-                    : 0.0,
-            stat->low_count + stat->high_count > 0
-                    ? (double)stat->high_count
-                              / (stat->low_count + stat->high_count) * 100.0
-                    : 0.0);
-
-    printf("Sibling Depth        : max=%d, avg=%.2f\n", stat->max_sibling_depth,
-            stat->total_nodes > 0
-                    ? (double)stat->total_sibling_depth / stat->total_nodes
-                    : 0.0);
-
-    printf("Word Compare Count   : max=%d, avg=%.2f\n",
-            stat->max_word_cmp_count,
-            stat->word_count > 0
-                    ? (double)stat->total_word_cmp_count / stat->word_count
-                    : 0.0);
-    printf("======================\n");
+    trie_stat_print(&stat, "mnode statistics");
 }
 
 static mnode *

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -16,8 +16,6 @@
 #include "wordbuf.h"
 #include "wordlist.h"
 
-#define MNODE_DEBUG_STAT 0
-
 #define MNODE_BUFSIZE    16384
 #define MNODE_BLOCK_SIZE 1024
 
@@ -43,8 +41,6 @@ struct mtree
     CHARSET_PROC_CHAR2INT char2int;
     CHARSET_PROC_INT2CHAR int2char;
 };
-
-#if MNODE_DEBUG_STAT
 
 typedef struct
 {
@@ -108,11 +104,17 @@ mnode_debug_stat(mnode *root, mnode_stat *stat)
     mnode_debug_stat_stub(root, stat, 0, 1);
 }
 
-static void
-mnode_print_stat(const mnode_stat *stat)
+void
+mnode_print_stat(mtree *mt)
 {
-    if (!stat)
+    if (!mt || !mt->rootnode)
+    {
+        printf("== INVALID mnode ===\n");
         return;
+    }
+
+    mnode_stat v, *stat = &v;
+    mnode_debug_stat(mt->rootnode, stat);
 
     printf("=== mnode statistics ===\n");
     printf("Total Nodes          : %zu\n", stat->total_nodes);
@@ -141,7 +143,6 @@ mnode_print_stat(const mnode_stat *stat)
                     : 0.0);
     printf("======================\n");
 }
-#endif
 
 static mnode *
 mnode_arena_alloc(mnode_arena *arena, unsigned int code)
@@ -422,14 +423,6 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
 END_MNODE_LOAD:
     wordbuf_close(buf);
     wordbuf_close(prevlabel);
-#if MNODE_DEBUG_STAT
-    if (mt && mt->rootnode)
-    {
-        mnode_stat st;
-        mnode_debug_stat(mt->rootnode, &st);
-        mnode_print_stat(&st);
-    }
-#endif
     return mt;
 }
 

--- a/src/mnode.h
+++ b/src/mnode.h
@@ -25,22 +25,25 @@ typedef struct mtree mtree;
 typedef void (*mnode_traverse_proc)(mnode *node, void *data);
 #define MNODE_TRAVERSE_PROC mnode_traverse_proc
 
-extern int n_mnode_new;
-extern int n_mnode_delete;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 mtree *mnode_open(void);
+
 mtree *mnode_load(mtree *root, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
         CHARSET_PROC_INT2CHAR int2char);
+
 void mnode_close(mtree *p);
+
 mnode *mnode_query(mtree *node, const unsigned char *query);
+
 void mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void *data);
 
 // Mainly for debugging purposes
 void mnode_print(mtree *mt, unsigned char *p);
+
+void mnode_print_stat(mtree *mt);
 
 #ifdef __cplusplus
 }

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "rxgen.h"
+#include "trie.h"
 #include "wordbuf.h"
 
 #if defined(_MSC_VER)
@@ -19,9 +20,6 @@
 #else
 # define STRDUP strdup
 #endif
-
-#define RXGEN_ENC_SJISTINY
-// #define RXGEN_OP_VIM
 
 #define RXGEN_OP_MAXLEN     8
 #define RXGEN_OP_OR         "|"
@@ -168,11 +166,6 @@ default_int2char(unsigned int in, unsigned char *out)
         case '^':
         case '$':
         case '/':
-#ifdef RXGEN_OP_VIM
-        case '[':
-        case ']':
-        case '~':
-#endif
             if (out)
                 out[len] = '\\';
             ++len;
@@ -400,24 +393,9 @@ rxgen_generate_stub(rxgen *object, wordbuf *buf, rnode *node)
 
 #if RXGEN_DEBUG_STAT
 
-typedef struct
-{
-    size_t total_nodes;
-    size_t low_count;
-    size_t high_count;
-    size_t child_count;
-    size_t wordtail_count;
-
-    int max_sibling_depth;
-    size_t total_sibling_depth;
-
-    int max_node_cmp_count;
-    size_t total_node_cmp_count;
-} rnode_stat;
-
 static void
 rnode_debug_stat_stub(
-        rnode *node, rnode_stat *stat, int sib_depth, int total_cmp)
+        rnode *node, trie_stat *stat, int sib_depth, int total_cmp)
 {
     if (!node)
         return;
@@ -451,36 +429,13 @@ rnode_debug_stat_stub(
 static void
 rnode_debug_stat(rnode *root)
 {
-    rnode_stat stat;
+    trie_stat stat;
     memset(&stat, 0, sizeof(stat));
     if (!root)
         return;
 
     rnode_debug_stat_stub(root, &stat, 0, 1);
-
-    printf("=== rnode statistics ===\n");
-    printf("Total Nodes          : %zu\n", stat.total_nodes);
-    printf("Wordtail Nodes       : %zu\n", stat.wordtail_count);
-    printf("Pointer Counts       : low=%zu, high=%zu, child=%zu\n",
-            stat.low_count, stat.high_count, stat.child_count);
-    printf("Low/High Balance Ratio: %.2f%% / %.2f%%\n",
-            stat.low_count + stat.high_count > 0
-                    ? (double)stat.low_count
-                              / (stat.low_count + stat.high_count) * 100.0
-                    : 0.0,
-            stat.low_count + stat.high_count > 0
-                    ? (double)stat.high_count
-                              / (stat.low_count + stat.high_count) * 100.0
-                    : 0.0);
-    printf("Sibling Depth        : max=%d, avg=%.2f\n", stat.max_sibling_depth,
-            stat.total_nodes > 0
-                    ? (double)stat.total_sibling_depth / stat.total_nodes
-                    : 0.0);
-    printf("Node Compare Count   : max=%d, avg=%.2f\n", stat.max_node_cmp_count,
-            stat.total_nodes > 0
-                    ? (double)stat.total_node_cmp_count / stat.total_nodes
-                    : 0.0);
-    printf("======================\n");
+    trie_stat_print(&stat, "rnode statistics");
 }
 
 #endif

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/mnode.c
   ${CMAKE_SOURCE_DIR}/src/romaji.c
   ${CMAKE_SOURCE_DIR}/src/rxgen.c
+  ${CMAKE_SOURCE_DIR}/src/trie.c
   ${CMAKE_SOURCE_DIR}/src/wordbuf.c
   ${CMAKE_SOURCE_DIR}/src/wordlist.c)
 target_include_directories(qspeed PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/src/testdir/profile_speed.c
+++ b/src/testdir/profile_speed.c
@@ -12,6 +12,7 @@
 #include <time.h>
 
 #include "migemo.h"
+#include "migemo_struct.h"
 
 #ifndef DICTDIR
 # define DICTDIR "../../dict"
@@ -47,13 +48,14 @@ main(int argc, char **argv)
     migemo *pmig;
     clock_t clock_load = 0, clock_query = 0, clock_tmp = 0;
 
-    printf("Start\n");
+    printf("Loading\n");
     clock_tmp = clock();
     pmig = migemo_open(DICTDIR "/migemo-dict");
     clock_load = clock() - clock_tmp;
-    printf("Loaded\n");
+    mnode_print_stat(pmig->mtree);
     if (pmig != NULL)
     {
+        printf("Quering\n");
         clock_query = profile_queries(pmig, NUM_TRIAL);
         migemo_close(pmig);
     }

--- a/src/trie.c
+++ b/src/trie.c
@@ -1,0 +1,41 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
+// trie.c -
+
+#include <stdio.h>
+
+#include "trie.h"
+
+void
+trie_stat_print(const trie_stat *stat, const char *title)
+{
+    printf("=== %s\n", title ? title : "");
+    printf("Total Nodes          : %zu\n", stat->total_nodes);
+    printf("Wordtail Nodes       : %zu\n", stat->wordtail_count);
+    printf("Pointer Counts       : low=%zu, high=%zu, child=%zu\n",
+            stat->low_count, stat->high_count, stat->child_count);
+    printf("Low/High Balance Ratio: %.2f%% / %.2f%%\n",
+            stat->low_count + stat->high_count > 0
+                    ? (double)stat->low_count
+                              / (stat->low_count + stat->high_count) * 100.0
+                    : 0.0,
+            stat->low_count + stat->high_count > 0
+                    ? (double)stat->high_count
+                              / (stat->low_count + stat->high_count) * 100.0
+                    : 0.0);
+    printf("Sibling Depth        : max=%d, avg=%.2f\n", stat->max_sibling_depth,
+            stat->total_nodes > 0
+                    ? (double)stat->total_sibling_depth / stat->total_nodes
+                    : 0.0);
+    printf("Node Compare Count   : max=%d, avg=%.2f\n",
+            stat->max_node_cmp_count,
+            stat->total_nodes > 0
+                    ? (double)stat->total_node_cmp_count / stat->total_nodes
+                    : 0.0);
+    printf("Word Compare Count   : max=%d, avg=%.2f\n",
+            stat->max_node_cmp_count,
+            stat->wordtail_count > 0
+                    ? (double)stat->total_node_cmp_count / stat->wordtail_count
+                    : 0.0);
+    printf("===\n");
+}

--- a/src/trie.h
+++ b/src/trie.h
@@ -1,0 +1,22 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
+// trie.h -
+
+#pragma once
+
+typedef struct
+{
+    size_t total_nodes;
+    size_t low_count;
+    size_t high_count;
+    size_t child_count;
+    size_t wordtail_count;
+
+    int max_sibling_depth;
+    size_t total_sibling_depth;
+
+    int max_node_cmp_count;
+    size_t total_node_cmp_count;
+} trie_stat;
+
+void trie_stat_print(const trie_stat *stat, const char *title);


### PR DESCRIPTION
refactor: consolidate trie statistics and expose print functionality

- Expose `mnode_print_stat` as a public function for printing trie statistics.
- Consolidate trie statistics handling into a unified `trie_stat` module.
- Clean up obsolete debug code and internal helper functions.