### PR TITLE
fix(dict): add source DAT files and dict-zh to build dependencies

### DIFF
--- a/dict/CMakeLists.txt
+++ b/dict/CMakeLists.txt
@@ -174,9 +174,13 @@ function(add_dict_encoding_target ENCODING_NAME ICONV_ENCODING IGNORE_ERROR)
     endif()
   endif()
 
+  set(DAT_PATHS ${DAT_FILES})
+  list(TRANSFORM DAT_PATHS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
   add_custom_command(
     OUTPUT ${OUT_DICT} ${COMMANDS_LIST}
-    DEPENDS ${BASE_DICT_PATH}
+    DEPENDS
+      ${BASE_DICT_PATH} ${DAT_PATHS} ${CMAKE_CURRENT_SOURCE_DIR}/migemo-dict-zh
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating ${ENCODING_NAME} dictionary")
 


### PR DESCRIPTION
### Summary
Fixes an issue where modifying source dictionary data files (such as `roma2hira.dat` or `migemo-dict-zh`) was not triggering a rebuild or re-copying to the build output directory when running `cmake --build`.

### Changes
- Prepend `${CMAKE_CURRENT_SOURCE_DIR}/` to `DAT_FILES` in `dict/CMakeLists.txt` using `list(TRANSFORM ... PREPEND)`.
- Add `${DAT_PATHS}` and `${CMAKE_CURRENT_SOURCE_DIR}/migemo-dict-zh` to the `DEPENDS` list of `add_custom_command` in `add_dict_encoding_target`.

### Verification
1. Modified `roma2hira.dat` in the source directory.
2. Ran `cmake --build build`.
3. Verified that the custom command re-executed and updated files under `build/dict/`.