### PR TITLE
refactor(strbuf): rename wordbuf to strbuf and optimize buffer operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Default dictionary search order (platform-dependent):
 ## Project Structure
 
 - `include/migemo.h` — Public C API (version 1.5)
-- `src/migemo.c`, `src/rxgen.c`, `src/romaji.c`, `src/charset.c`, `src/wordbuf.c`, `src/wordlist.c`, `src/mnode.c`, `src/filename.c` — Core library (`migemo` shared lib)
+- `src/migemo.c`, `src/rxgen.c`, `src/romaji.c`, `src/charset.c`, `src/strbuf.c`, `src/wordlist.c`, `src/mnode.c`, `src/filename.c` — Core library (`migemo` shared lib)
 - `src/main.c` — CLI executable (`cmigemo`)
 - `src/testdir/romaji_main.c` — Romaji conversion tool
 - `src/testdir/profile_speed.c` — qspeed benchmark tool

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(
     romaji.c
     rxgen.c
     trie.c
-    wordbuf.c
+    strbuf.c
     wordlist.c)
 
 set_target_properties(

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -19,7 +19,7 @@
 #include "mnode.h"
 #include "romaji.h"
 #include "rxgen.h"
-#include "wordbuf.h"
+#include "strbuf.h"
 #include "wordlist.h"
 
 #define DICT_MIGEMO    "migemo-dict"
@@ -423,7 +423,7 @@ migemo_query(migemo *object, const unsigned char *query)
 {
     unsigned char *retval = NULL;
     wordlist *querylist = NULL;
-    wordbuf *outbuf = NULL;
+    strbuf *outbuf = NULL;
 
     if (object && object->rx && query)
     {
@@ -432,7 +432,7 @@ migemo_query(migemo *object, const unsigned char *query)
         querylist = parse_query(object, query);
         if (querylist == NULL)
             goto MIGEMO_QUERY_END; // Error due to empty query
-        outbuf = wordbuf_open();
+        outbuf = strbuf_open();
         if (outbuf == NULL)
             goto MIGEMO_QUERY_END; // Error due to insufficient memory for
                                    // output
@@ -449,7 +449,7 @@ migemo_query(migemo *object, const unsigned char *query)
             // Generate search pattern (regular expression)
             answer = rxgen_generate(object->rx);
             rxgen_reset(object->rx);
-            wordbuf_cat(outbuf, answer);
+            strbuf_cat(outbuf, answer);
             rxgen_release(object->rx, answer);
         }
     }
@@ -457,10 +457,10 @@ migemo_query(migemo *object, const unsigned char *query)
 MIGEMO_QUERY_END:
     if (outbuf)
     {
-        retval = wordbuf_get(outbuf);
-        // Explicitly set to NULL to decouple it from `wordbuf` management.
+        retval = strbuf_get(outbuf);
+        // Explicitly set to NULL to decouple it from `strbuf` management.
         outbuf->buf = NULL;
-        wordbuf_close(outbuf);
+        strbuf_close(outbuf);
     }
     if (querylist)
         wordlist_destroy(querylist);

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -449,7 +449,7 @@ migemo_query(migemo *object, const unsigned char *query)
             // Generate search pattern (regular expression)
             answer = rxgen_generate(object->rx);
             rxgen_reset(object->rx);
-            strbuf_cat(outbuf, answer);
+            strbuf_append_str(outbuf, answer);
             rxgen_release(object->rx, answer);
         }
     }

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -457,7 +457,8 @@ migemo_query(migemo *object, const unsigned char *query)
 MIGEMO_QUERY_END:
     if (outbuf)
     {
-        retval = outbuf->buf;
+        retval = wordbuf_get(outbuf);
+        // Explicitly set to NULL to decouple it from `wordbuf` management.
         outbuf->buf = NULL;
         wordbuf_close(outbuf);
     }

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -13,8 +13,8 @@
 
 #include "charset.h"
 #include "mnode.h"
+#include "strbuf.h"
 #include "trie.h"
-#include "wordbuf.h"
 #include "wordlist.h"
 
 #define MNODE_BUFSIZE    16384
@@ -192,12 +192,12 @@ decode_rune(mtree *mt, const unsigned char **pp)
 }
 
 static mnode *
-search_or_new_mnode(mtree *mt, wordbuf *buf)
+search_or_new_mnode(mtree *mt, strbuf *buf)
 {
     // Add to the search tree once the label word is determined
     mnode **res = NULL;
 
-    const unsigned char *word = wordbuf_get(buf);
+    const unsigned char *word = strbuf_get(buf);
     if (!word)
         return NULL;
     unsigned int code = decode_rune(mt, &word);
@@ -302,8 +302,8 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
     mnode *pp = NULL;
     int mode = 0;
     int ch;
-    wordbuf *buf;
-    wordbuf *prevlabel;
+    strbuf *buf;
+    strbuf *prevlabel;
     wordlist **ppword = NULL; // To suppress warning for GCC
     // Variables for the input buffer
     unsigned char cache[MNODE_BUFSIZE];
@@ -313,8 +313,8 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
     mt->char2int = char2int;
     mt->int2char = int2char;
 
-    buf = wordbuf_open();
-    prevlabel = wordbuf_open();
+    buf = strbuf_open();
+    prevlabel = strbuf_open();
     if (!fp || !buf || !prevlabel)
     {
         mt = NULL;
@@ -353,8 +353,8 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                 else
                 {
                     mode = 1; // Switch to mode for reading label words
-                    wordbuf_reset(buf);
-                    wordbuf_add(buf, (unsigned char)ch);
+                    strbuf_reset(buf);
+                    strbuf_add(buf, (unsigned char)ch);
                 }
                 break;
 
@@ -363,7 +363,7 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                 switch (ch)
                 {
                     default:
-                        wordbuf_add(buf, (unsigned char)ch);
+                        strbuf_add(buf, (unsigned char)ch);
                         break;
                     case '\t':
                         pp = search_or_new_mnode(mt, buf);
@@ -372,7 +372,7 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                             mt = NULL;
                             goto END_MNODE_LOAD;
                         }
-                        wordbuf_reset(buf);
+                        strbuf_reset(buf);
                         mode = 3; // Switch to mode for skipping whitespace
                                   // before words
                         break;
@@ -382,7 +382,7 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
             case 2: // Mode that consumes until end of line
                 if (ch == '\n')
                 {
-                    wordbuf_reset(buf);
+                    strbuf_reset(buf);
                     mode = 0; // Return to label word search mode
                 }
                 break;
@@ -390,14 +390,14 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
             case 3: // Mode for skipping whitespace before words
                 if (ch == '\n')
                 {
-                    wordbuf_reset(buf);
+                    strbuf_reset(buf);
                     mode = 0; // Return to label word search mode
                 }
                 else if (ch != '\t')
                 {
                     // Reset word buffer
-                    wordbuf_reset(buf);
-                    wordbuf_add(buf, (unsigned char)ch);
+                    strbuf_reset(buf);
+                    strbuf_add(buf, (unsigned char)ch);
                     // Search for the end of the word list (if multiple words
                     // for same label)
                     ppword = &pp->list;
@@ -413,9 +413,9 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                     case '\t':
                     case '\n':
                         // Store word
-                        *ppword = wordlist_new(
-                                wordbuf_get(buf), wordbuf_len(buf));
-                        wordbuf_reset(buf);
+                        *ppword =
+                                wordlist_new(strbuf_get(buf), strbuf_len(buf));
+                        strbuf_reset(buf);
 
                         if (ch == '\t')
                         {
@@ -430,7 +430,7 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                         }
                         break;
                     default:
-                        wordbuf_add(buf, (unsigned char)ch);
+                        strbuf_add(buf, (unsigned char)ch);
                         break;
                 }
                 break;
@@ -441,8 +441,8 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
     mt->rootnode = mnode_balance(mt->rootnode);
 
 END_MNODE_LOAD:
-    wordbuf_close(buf);
-    wordbuf_close(prevlabel);
+    strbuf_close(buf);
+    strbuf_close(prevlabel);
     return mt;
 }
 

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -197,7 +197,7 @@ search_or_new_mnode(mtree *mt, wordbuf *buf)
     // Add to the search tree once the label word is determined
     mnode **res = NULL;
 
-    const unsigned char *word = WORDBUF_GET(buf);
+    const unsigned char *word = wordbuf_get(buf);
     if (!word)
         return NULL;
     unsigned int code = decode_rune(mt, &word);
@@ -414,7 +414,7 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                     case '\n':
                         // Store word
                         *ppword = wordlist_new(
-                                WORDBUF_GET(buf), WORDBUF_LEN(buf));
+                                wordbuf_get(buf), wordbuf_len(buf));
                         wordbuf_reset(buf);
 
                         if (ch == '\t')

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -543,7 +543,7 @@ add_pending_node(wordlist *tail, romanode *node, wordbuf *prefix)
         {
             wordbuf_append(w, prefix);
             wordbuf_cat(w, node->value);
-            wordlist *item = wordlist_new(w->buf, w->last);
+            wordlist *item = wordlist_new(wordbuf_get(w), wordbuf_len(w));
             tail->next = item;
             tail = item;
             wordbuf_close(w);
@@ -591,14 +591,15 @@ romaji_convert_all(romaji *object, const unsigned char *src)
         {
             wordbuf_write_bytes(pending, prev, curr - prev);
             // Consume a code from the pending, add it to dstbuf.
-            size_t len = decode_len(object->char2int, pending->buf);
-            wordbuf_write_bytes(dstbuf, pending->buf, len);
+            unsigned char *p = wordbuf_get(pending);
+            size_t len = decode_len(object->char2int, p);
+            wordbuf_write_bytes(dstbuf, p, len);
             // Push the pending remainder to the front of srcbuf.
-            size_t rem_len = pending->last - len;
+            size_t rem_len = wordbuf_len(pending) - len;
             if (curr < srcbuf + rem_len) // Check if srcbuf has underflowed.
                 goto END;
             curr -= rem_len;
-            memcpy(curr, pending->buf + len, rem_len);
+            memcpy(curr, p + len, rem_len);
             wordbuf_reset(pending);
             // Start the next search from the root.
             node = NULL;
@@ -627,8 +628,8 @@ romaji_convert_all(romaji *object, const unsigned char *src)
         wordbuf_write_bytes(pending, prev, curr - prev);
     }
 
-    if (pending->last == 0)
-        list = wordlist_new(dstbuf->buf, dstbuf->last);
+    if (wordbuf_len(pending) == 0)
+        list = wordlist_new(wordbuf_get(dstbuf), wordbuf_len(dstbuf));
     else
     {
         // Output all entries under the pending node.

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -542,7 +542,7 @@ add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
         if (w)
         {
             strbuf_append(w, prefix);
-            strbuf_cat(w, node->value);
+            strbuf_append_str(w, node->value);
             wordlist *item = wordlist_new(strbuf_get(w), strbuf_len(w));
             tail->next = item;
             tail = item;
@@ -589,11 +589,11 @@ romaji_convert_all(romaji *object, const unsigned char *src)
 
         if (!node)
         {
-            strbuf_write_bytes(pending, prev, curr - prev);
+            strbuf_append_mem(pending, prev, curr - prev);
             // Consume a code from the pending, add it to dstbuf.
             unsigned char *p = strbuf_get(pending);
             size_t len = decode_len(object->char2int, p);
-            strbuf_write_bytes(dstbuf, p, len);
+            strbuf_append_mem(dstbuf, p, len);
             // Push the pending remainder to the front of srcbuf.
             size_t rem_len = strbuf_len(pending) - len;
             if (curr < srcbuf + rem_len) // Check if srcbuf has underflowed.
@@ -608,7 +608,7 @@ romaji_convert_all(romaji *object, const unsigned char *src)
 
         if (node->value)
         {
-            strbuf_cat(dstbuf, node->value);
+            strbuf_append_str(dstbuf, node->value);
             // Push node->remain to front of curr.
             if (node->remain)
             {
@@ -625,7 +625,7 @@ romaji_convert_all(romaji *object, const unsigned char *src)
             continue;
         }
 
-        strbuf_write_bytes(pending, prev, curr - prev);
+        strbuf_append_mem(pending, prev, curr - prev);
     }
 
     if (strbuf_len(pending) == 0)

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -13,8 +13,8 @@
 
 #include "charset.h"
 #include "romaji.h"
+#include "strbuf.h"
 #include "trie.h"
-#include "wordbuf.h"
 
 #if defined(_MSC_VER)
 # define STRDUP _strdup
@@ -531,22 +531,22 @@ decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
 }
 
 static wordlist *
-add_pending_node(wordlist *tail, romanode *node, wordbuf *prefix)
+add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
 {
     if (!node)
         return tail;
     tail = add_pending_node(tail, node->low, prefix);
     if (node->value)
     {
-        wordbuf *w = wordbuf_open();
+        strbuf *w = strbuf_open();
         if (w)
         {
-            wordbuf_append(w, prefix);
-            wordbuf_cat(w, node->value);
-            wordlist *item = wordlist_new(wordbuf_get(w), wordbuf_len(w));
+            strbuf_append(w, prefix);
+            strbuf_cat(w, node->value);
+            wordlist *item = wordlist_new(strbuf_get(w), strbuf_len(w));
             tail->next = item;
             tail = item;
-            wordbuf_close(w);
+            strbuf_close(w);
         }
     }
     tail = add_pending_node(tail, node->child, prefix);
@@ -559,8 +559,8 @@ romaji_convert_all(romaji *object, const unsigned char *src)
 {
     wordlist *list = NULL;
     unsigned char *srcbuf = NULL;
-    wordbuf *dstbuf = NULL;
-    wordbuf *pending = NULL;
+    strbuf *dstbuf = NULL;
+    strbuf *pending = NULL;
 
     size_t srclen = strlen(src);
     srcbuf = calloc(1, ROMAJI_PUSHBACK_BUFSIZE + srclen + 1);
@@ -569,10 +569,10 @@ romaji_convert_all(romaji *object, const unsigned char *src)
     unsigned char *curr = srcbuf + ROMAJI_PUSHBACK_BUFSIZE;
     memcpy(curr, src, srclen + 1);
 
-    dstbuf = wordbuf_open();
+    dstbuf = strbuf_open();
     if (!dstbuf)
         goto END;
-    pending = wordbuf_open();
+    pending = strbuf_open();
     if (!pending)
         goto END;
 
@@ -589,18 +589,18 @@ romaji_convert_all(romaji *object, const unsigned char *src)
 
         if (!node)
         {
-            wordbuf_write_bytes(pending, prev, curr - prev);
+            strbuf_write_bytes(pending, prev, curr - prev);
             // Consume a code from the pending, add it to dstbuf.
-            unsigned char *p = wordbuf_get(pending);
+            unsigned char *p = strbuf_get(pending);
             size_t len = decode_len(object->char2int, p);
-            wordbuf_write_bytes(dstbuf, p, len);
+            strbuf_write_bytes(dstbuf, p, len);
             // Push the pending remainder to the front of srcbuf.
-            size_t rem_len = wordbuf_len(pending) - len;
+            size_t rem_len = strbuf_len(pending) - len;
             if (curr < srcbuf + rem_len) // Check if srcbuf has underflowed.
                 goto END;
             curr -= rem_len;
             memcpy(curr, p + len, rem_len);
-            wordbuf_reset(pending);
+            strbuf_reset(pending);
             // Start the next search from the root.
             node = NULL;
             continue;
@@ -608,7 +608,7 @@ romaji_convert_all(romaji *object, const unsigned char *src)
 
         if (node->value)
         {
-            wordbuf_cat(dstbuf, node->value);
+            strbuf_cat(dstbuf, node->value);
             // Push node->remain to front of curr.
             if (node->remain)
             {
@@ -619,17 +619,17 @@ romaji_convert_all(romaji *object, const unsigned char *src)
                 curr -= len;
                 memcpy(curr, node->remain, len);
             }
-            wordbuf_reset(pending);
+            strbuf_reset(pending);
             // Start the next search from the root.
             node = NULL;
             continue;
         }
 
-        wordbuf_write_bytes(pending, prev, curr - prev);
+        strbuf_write_bytes(pending, prev, curr - prev);
     }
 
-    if (wordbuf_len(pending) == 0)
-        list = wordlist_new(wordbuf_get(dstbuf), wordbuf_len(dstbuf));
+    if (strbuf_len(pending) == 0)
+        list = wordlist_new(strbuf_get(dstbuf), strbuf_len(dstbuf));
     else
     {
         // Output all entries under the pending node.
@@ -641,7 +641,7 @@ romaji_convert_all(romaji *object, const unsigned char *src)
 
 END:
     free(srcbuf);
-    wordbuf_close(dstbuf);
-    wordbuf_close(pending);
+    strbuf_close(dstbuf);
+    strbuf_close(pending);
     return list;
 }

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -456,7 +456,7 @@ rxgen_generate(rxgen *object)
 #endif
             rxgen_generate_stub(object, buf, object->root);
         }
-        answer = STRDUP(WORDBUF_GET(buf));
+        answer = STRDUP(wordbuf_get(buf));
         wordbuf_close(buf);
     }
     return answer;

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -12,8 +12,8 @@
 #include <string.h>
 
 #include "rxgen.h"
+#include "strbuf.h"
 #include "trie.h"
-#include "wordbuf.h"
 
 #if defined(_MSC_VER)
 # define STRDUP _strdup
@@ -302,18 +302,18 @@ rxgen_rnode_count(rnode *node, int *childrenCount, int *brotherCount)
     }
 }
 
-static void rxgen_generate_stub(rxgen *object, wordbuf *buf, rnode *node);
+static void rxgen_generate_stub(rxgen *object, strbuf *buf, rnode *node);
 
 static void
-rxgen_write_node_code(rxgen *object, wordbuf *buf, rnode *node)
+rxgen_write_node_code(rxgen *object, strbuf *buf, rnode *node)
 {
     unsigned char bytes[6];
     int len = rxgen_call_int2char(object, node->code, bytes);
-    wordbuf_write_bytes(buf, bytes, len);
+    strbuf_write_bytes(buf, bytes, len);
 }
 
 static void
-rxgen_write_node_no_children(rxgen *object, wordbuf *buf, rnode *node)
+rxgen_write_node_no_children(rxgen *object, strbuf *buf, rnode *node)
 {
     if (node->low)
         rxgen_write_node_no_children(object, buf, node->low);
@@ -325,7 +325,7 @@ rxgen_write_node_no_children(rxgen *object, wordbuf *buf, rnode *node)
 
 static void
 rxgen_write_node_has_children(
-        rxgen *object, wordbuf *buf, rnode *node, bool *needOr)
+        rxgen *object, strbuf *buf, rnode *node, bool *needOr)
 {
     if (node->low)
         rxgen_write_node_has_children(object, buf, node->low, needOr);
@@ -333,11 +333,11 @@ rxgen_write_node_has_children(
     {
         // Output OR if necessary
         if (*needOr)
-            wordbuf_cat(buf, object->op_or);
+            strbuf_cat(buf, object->op_or);
         rxgen_write_node_code(object, buf, node);
         // Insert a pattern that skips whitespace/newline
         if (object->op_newline[0])
-            wordbuf_cat(buf, object->op_newline);
+            strbuf_cat(buf, object->op_newline);
         rxgen_generate_stub(object, buf, node->child);
         *needOr = true;
     }
@@ -346,7 +346,7 @@ rxgen_write_node_has_children(
 }
 
 static void
-rxgen_generate_stub(rxgen *object, wordbuf *buf, rnode *node)
+rxgen_generate_stub(rxgen *object, strbuf *buf, rnode *node)
 {
     // Check characteristics of the current level (number of siblings, number of
     // children)
@@ -364,16 +364,16 @@ rxgen_generate_stub(rxgen *object, wordbuf *buf, rnode *node)
 
     // Group using () if necessary
     if (needGroup)
-        wordbuf_cat(buf, object->op_nest_in);
+        strbuf_cat(buf, object->op_nest_in);
 
     // Group nodes without children first with []
     if (noChildrenCount > 0)
     {
         if (needClass)
         {
-            wordbuf_cat(buf, object->op_select_in);
+            strbuf_cat(buf, object->op_select_in);
             rxgen_write_node_no_children(object, buf, node);
-            wordbuf_cat(buf, object->op_select_out);
+            strbuf_cat(buf, object->op_select_out);
         }
         else
             rxgen_write_node_no_children(object, buf, node);
@@ -388,7 +388,7 @@ rxgen_generate_stub(rxgen *object, wordbuf *buf, rnode *node)
 
     // Group using () if necessary
     if (needGroup)
-        wordbuf_cat(buf, object->op_nest_out);
+        strbuf_cat(buf, object->op_nest_out);
 }
 
 #if RXGEN_DEBUG_STAT
@@ -444,9 +444,9 @@ unsigned char *
 rxgen_generate(rxgen *object)
 {
     unsigned char *answer = NULL;
-    wordbuf *buf;
+    strbuf *buf;
 
-    if (object && (buf = wordbuf_open()))
+    if (object && (buf = strbuf_open()))
     {
 
         if (object->root)
@@ -456,8 +456,8 @@ rxgen_generate(rxgen *object)
 #endif
             rxgen_generate_stub(object, buf, object->root);
         }
-        answer = STRDUP(wordbuf_get(buf));
-        wordbuf_close(buf);
+        answer = STRDUP(strbuf_get(buf));
+        strbuf_close(buf);
     }
     return answer;
 }

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -309,7 +309,7 @@ rxgen_write_node_code(rxgen *object, strbuf *buf, rnode *node)
 {
     unsigned char bytes[6];
     int len = rxgen_call_int2char(object, node->code, bytes);
-    strbuf_write_bytes(buf, bytes, len);
+    strbuf_append_mem(buf, bytes, len);
 }
 
 static void
@@ -333,11 +333,11 @@ rxgen_write_node_has_children(
     {
         // Output OR if necessary
         if (*needOr)
-            strbuf_cat(buf, object->op_or);
+            strbuf_append_str(buf, object->op_or);
         rxgen_write_node_code(object, buf, node);
         // Insert a pattern that skips whitespace/newline
         if (object->op_newline[0])
-            strbuf_cat(buf, object->op_newline);
+            strbuf_append_str(buf, object->op_newline);
         rxgen_generate_stub(object, buf, node->child);
         *needOr = true;
     }
@@ -364,16 +364,16 @@ rxgen_generate_stub(rxgen *object, strbuf *buf, rnode *node)
 
     // Group using () if necessary
     if (needGroup)
-        strbuf_cat(buf, object->op_nest_in);
+        strbuf_append_str(buf, object->op_nest_in);
 
     // Group nodes without children first with []
     if (noChildrenCount > 0)
     {
         if (needClass)
         {
-            strbuf_cat(buf, object->op_select_in);
+            strbuf_append_str(buf, object->op_select_in);
             rxgen_write_node_no_children(object, buf, node);
-            strbuf_cat(buf, object->op_select_out);
+            strbuf_append_str(buf, object->op_select_out);
         }
         else
             rxgen_write_node_no_children(object, buf, node);
@@ -388,7 +388,7 @@ rxgen_generate_stub(rxgen *object, strbuf *buf, rnode *node)
 
     // Group using () if necessary
     if (needGroup)
-        strbuf_cat(buf, object->op_nest_out);
+        strbuf_append_str(buf, object->op_nest_out);
 }
 
 #if RXGEN_DEBUG_STAT

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -1,6 +1,6 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// wordbuf.h -
+// strbuf.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
@@ -11,19 +11,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "wordbuf.h"
+#include "strbuf.h"
 
-#define WORDBUF_DEFAULT_SIZE 64
-#define WORDBUF_MAX_SIZE     (8 * 1024 * 1024)
+#define STRBUF_DEFAULT_SIZE 64
+#define STRBUF_MAX_SIZE     (8 * 1024 * 1024)
 
-wordbuf *
-wordbuf_open()
+strbuf *
+strbuf_open()
 {
-    wordbuf *p = (wordbuf *)malloc(sizeof(wordbuf));
+    strbuf *p = (strbuf *)malloc(sizeof(strbuf));
     if (!p)
         return NULL;
 
-    p->cap = WORDBUF_DEFAULT_SIZE;
+    p->cap = STRBUF_DEFAULT_SIZE;
     p->buf = (unsigned char *)malloc(p->cap);
     if (!p->buf)
     {
@@ -36,7 +36,7 @@ wordbuf_open()
 }
 
 void
-wordbuf_close(wordbuf *p)
+strbuf_close(strbuf *p)
 {
     if (p)
     {
@@ -45,13 +45,13 @@ wordbuf_close(wordbuf *p)
     }
 }
 
-// wordbuf_extend(wordbuf * p, int req_len);
+// strbuf_extend(strbuf * p, int req_len);
 //	Expand the buffer. Returns 0 on error.
 //	The caller decides whether to expand for performance.
 size_t
-wordbuf_extend(wordbuf *p, size_t req_len)
+strbuf_extend(strbuf *p, size_t req_len)
 {
-    if (req_len > WORDBUF_MAX_SIZE)
+    if (req_len > STRBUF_MAX_SIZE)
         return 0;
 
     size_t newlen = p->cap * 2;
@@ -61,7 +61,7 @@ wordbuf_extend(wordbuf *p, size_t req_len)
         newlen *= 2;
     if (!(newbuf = (unsigned char *)realloc(p->buf, newlen)))
     {
-        // fprintf(stderr, "wordbuf_add(): failed to extend buffer\n");
+        // fprintf(stderr, "strbuf_add(): failed to extend buffer\n");
         return 0;
     }
     else
@@ -73,13 +73,13 @@ wordbuf_extend(wordbuf *p, size_t req_len)
 }
 
 size_t
-wordbuf_append(wordbuf *p, wordbuf *q)
+strbuf_append(strbuf *p, strbuf *q)
 {
-    return wordbuf_write_bytes(p, q->buf, q->len);
+    return strbuf_write_bytes(p, q->buf, q->len);
 }
 
 size_t
-wordbuf_cat(wordbuf *p, const unsigned char *sz)
+strbuf_cat(strbuf *p, const unsigned char *sz)
 {
     size_t len = 0;
 
@@ -93,7 +93,7 @@ wordbuf_cat(wordbuf *p, const unsigned char *sz)
     {
         size_t newlen = (size_t)p->len + len + 1;
 
-        if (newlen > p->cap && !wordbuf_extend(p, newlen))
+        if (newlen > p->cap && !strbuf_extend(p, newlen))
             return 0;
         memcpy(&p->buf[p->len], sz, len + 1);
         p->len += len;
@@ -102,12 +102,12 @@ wordbuf_cat(wordbuf *p, const unsigned char *sz)
 }
 
 size_t
-wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len)
+strbuf_write_bytes(strbuf *buf, const unsigned char *p, size_t len)
 {
     if (p != NULL && len > 0)
     {
         size_t newlen = buf->len + len + 1;
-        if (newlen > buf->cap && !wordbuf_extend(buf, newlen))
+        if (newlen > buf->cap && !strbuf_extend(buf, newlen))
             return 0;
         memcpy(&buf->buf[buf->len], p, len);
         buf->len += len;

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -19,107 +19,107 @@
 strbuf *
 strbuf_open()
 {
-    strbuf *p = (strbuf *)malloc(sizeof(strbuf));
-    if (!p)
+    strbuf *sb = (strbuf *)malloc(sizeof(strbuf));
+    if (!sb)
         return NULL;
 
-    p->cap = STRBUF_DEFAULT_SIZE;
-    p->buf = (unsigned char *)malloc(p->cap);
-    if (!p->buf)
+    sb->cap = STRBUF_DEFAULT_SIZE;
+    sb->buf = (unsigned char *)malloc(sb->cap);
+    if (!sb->buf)
     {
-        free(p);
+        free(sb);
         return NULL;
     }
-    p->len = 0;
-    p->buf[0] = '\0';
-    return p;
+    sb->len = 0;
+    sb->buf[0] = '\0';
+    return sb;
 }
 
 void
-strbuf_close(strbuf *p)
+strbuf_close(strbuf *sb)
 {
-    if (p)
+    if (sb)
     {
-        free(p->buf);
-        free(p);
+        free(sb->buf);
+        free(sb);
     }
 }
 
-// strbuf_extend(strbuf * p, int req_len);
+// strbuf_extend(strbuf * sb, int req_len);
 //	Expand the buffer. Returns 0 on error.
 //	The caller decides whether to expand for performance.
 size_t
-strbuf_extend(strbuf *p, size_t req_len)
+strbuf_extend(strbuf *sb, size_t req_len)
 {
     if (req_len > STRBUF_MAX_SIZE)
         return 0;
 
-    size_t newlen = p->cap * 2;
+    size_t newlen = sb->cap * 2;
     unsigned char *newbuf;
 
     while (req_len > newlen)
         newlen *= 2;
-    if (!(newbuf = (unsigned char *)realloc(p->buf, newlen)))
+    if (!(newbuf = (unsigned char *)realloc(sb->buf, newlen)))
     {
         // fprintf(stderr, "strbuf_add(): failed to extend buffer\n");
         return 0;
     }
     else
     {
-        p->cap = newlen;
-        p->buf = newbuf;
+        sb->cap = newlen;
+        sb->buf = newbuf;
         return req_len;
     }
 }
 
 size_t
-strbuf_append_ch(strbuf *p, unsigned char ch)
+strbuf_append_ch(strbuf *sb, unsigned char ch)
 {
-    if (!strbuf_extend(p, p->len + 2))
+    if (!strbuf_extend(sb, sb->len + 2))
         return 0;
-    return strbuf_add(p, ch);
+    return strbuf_add(sb, ch);
 }
 
 size_t
-strbuf_append(strbuf *p, strbuf *q)
+strbuf_append(strbuf *sb, strbuf *q)
 {
-    return strbuf_write_bytes(p, q->buf, q->len);
+    return strbuf_append_mem(sb, q->buf, q->len);
 }
 
 size_t
-strbuf_cat(strbuf *p, const unsigned char *sz)
+strbuf_append_str(strbuf *sb, const unsigned char *s)
 {
     size_t len = 0;
 
-    if (sz != NULL)
+    if (s != NULL)
     {
-        size_t l = strlen(sz);
+        size_t l = strlen(s);
         len = l < INT_MAX ? l : INT_MAX;
     }
 
     if (len > 0)
     {
-        size_t newlen = (size_t)p->len + len + 1;
+        size_t newlen = (size_t)sb->len + len + 1;
 
-        if (newlen > p->cap && !strbuf_extend(p, newlen))
+        if (newlen > sb->cap && !strbuf_extend(sb, newlen))
             return 0;
-        memcpy(&p->buf[p->len], sz, len + 1);
-        p->len += len;
+        memcpy(&sb->buf[sb->len], s, len + 1);
+        sb->len += len;
     }
-    return p->len;
+    return sb->len;
 }
 
 size_t
-strbuf_write_bytes(strbuf *buf, const unsigned char *p, size_t len)
+strbuf_append_mem(strbuf *sb, const unsigned char *p, size_t len)
 {
     if (p != NULL && len > 0)
     {
-        size_t newlen = buf->len + len + 1;
-        if (newlen > buf->cap && !strbuf_extend(buf, newlen))
+        size_t newlen = sb->len + len + 1;
+        if (newlen > sb->cap && !strbuf_extend(sb, newlen))
             return 0;
-        memcpy(&buf->buf[buf->len], p, len);
-        buf->len += len;
-        buf->buf[buf->len] = '\0';
+        memcpy(&sb->buf[sb->len], p, len);
+        sb->len += len;
+        sb->buf[sb->len] = '\0';
     }
-    return buf->len;
+    return sb->len;
 }

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -73,6 +73,14 @@ strbuf_extend(strbuf *p, size_t req_len)
 }
 
 size_t
+strbuf_append_ch(strbuf *p, unsigned char ch)
+{
+    if (!strbuf_extend(p, p->len + 2))
+        return 0;
+    return strbuf_add(p, ch);
+}
+
+size_t
 strbuf_append(strbuf *p, strbuf *q)
 {
     return strbuf_write_bytes(p, q->buf, q->len);

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -19,44 +19,44 @@ extern "C" {
 #endif
 
 strbuf *strbuf_open();
-void strbuf_close(strbuf *p);
-size_t strbuf_extend(strbuf *p, size_t req_len);
-size_t strbuf_append(strbuf *p, strbuf *q);
-size_t strbuf_append_ch(strbuf *p, unsigned char ch);
-size_t strbuf_cat(strbuf *p, const unsigned char *sz);
-size_t strbuf_write_bytes(strbuf *buf, const unsigned char *p, size_t len);
+void strbuf_close(strbuf *sb);
+size_t strbuf_extend(strbuf *sb, size_t req_len);
+size_t strbuf_append(strbuf *sb, strbuf *q);
+size_t strbuf_append_ch(strbuf *sb, unsigned char ch);
+size_t strbuf_append_str(strbuf *sb, const unsigned char *s);
+size_t strbuf_append_mem(strbuf *sb, const unsigned char *p, size_t len);
 
 #ifdef __cplusplus
 }
 #endif
 
 static inline size_t
-strbuf_len(strbuf *p)
+strbuf_len(strbuf *sb)
 {
-    return p->len;
+    return sb->len;
 }
 
 static inline unsigned char *
-strbuf_get(strbuf *p)
+strbuf_get(strbuf *sb)
 {
-    return p->buf;
+    return sb->buf;
 }
 
 static inline void
-strbuf_reset(strbuf *p)
+strbuf_reset(strbuf *sb)
 {
-    p->len = 0;
-    p->buf[0] = '\0';
+    sb->len = 0;
+    sb->buf[0] = '\0';
 }
 
 static inline size_t
-strbuf_add(strbuf *p, unsigned char ch)
+strbuf_add(strbuf *sb, unsigned char ch)
 {
-    if (p->len + 2 <= p->cap)
+    if (sb->len + 2 <= sb->cap)
     {
-        p->buf[p->len++] = ch;
-        p->buf[p->len] = 0;
-        return p->len;
+        sb->buf[sb->len++] = ch;
+        sb->buf[sb->len] = 0;
+        return sb->len;
     }
-    return strbuf_append_ch(p, ch);
+    return strbuf_append_ch(sb, ch);
 }

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -1,13 +1,13 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// wordbuf.h -
+// strbuf.h -
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
 #pragma once
 
-typedef struct wordbuf wordbuf;
-struct wordbuf
+typedef struct strbuf strbuf;
+struct strbuf
 {
     size_t cap; // amount of memory allocated to buf
     size_t len; // length of the string actually stored in buf
@@ -18,42 +18,42 @@ struct wordbuf
 extern "C" {
 #endif
 
-wordbuf *wordbuf_open();
-void wordbuf_close(wordbuf *p);
-size_t wordbuf_extend(wordbuf *p, size_t req_len);
-size_t wordbuf_append(wordbuf *p, wordbuf *q);
-size_t wordbuf_cat(wordbuf *p, const unsigned char *sz);
-size_t wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len);
+strbuf *strbuf_open();
+void strbuf_close(strbuf *p);
+size_t strbuf_extend(strbuf *p, size_t req_len);
+size_t strbuf_append(strbuf *p, strbuf *q);
+size_t strbuf_cat(strbuf *p, const unsigned char *sz);
+size_t strbuf_write_bytes(strbuf *buf, const unsigned char *p, size_t len);
 
 #ifdef __cplusplus
 }
 #endif
 
 static inline size_t
-wordbuf_len(wordbuf *p)
+strbuf_len(strbuf *p)
 {
     return p->len;
 }
 
 static inline unsigned char *
-wordbuf_get(wordbuf *p)
+strbuf_get(strbuf *p)
 {
     return p->buf;
 }
 
 static inline void
-wordbuf_reset(wordbuf *p)
+strbuf_reset(strbuf *p)
 {
     p->len = 0;
     p->buf[0] = '\0';
 }
 
 static inline size_t
-wordbuf_add(wordbuf *p, unsigned char ch)
+strbuf_add(strbuf *p, unsigned char ch)
 {
     size_t newlen = p->len + 2;
     if (newlen > p->cap)
-        if (!wordbuf_extend(p, newlen))
+        if (!strbuf_extend(p, newlen))
             return 0;
 
     p->buf[p->len++] = ch;

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -18,9 +18,12 @@ struct strbuf
 extern "C" {
 #endif
 
+// Life cycle managements
 strbuf *strbuf_open();
 void strbuf_close(strbuf *sb);
 size_t strbuf_extend(strbuf *sb, size_t req_len);
+
+// Append functions
 size_t strbuf_append(strbuf *sb, strbuf *q);
 size_t strbuf_append_ch(strbuf *sb, unsigned char ch);
 size_t strbuf_append_str(strbuf *sb, const unsigned char *s);

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -22,6 +22,7 @@ strbuf *strbuf_open();
 void strbuf_close(strbuf *p);
 size_t strbuf_extend(strbuf *p, size_t req_len);
 size_t strbuf_append(strbuf *p, strbuf *q);
+size_t strbuf_append_ch(strbuf *p, unsigned char ch);
 size_t strbuf_cat(strbuf *p, const unsigned char *sz);
 size_t strbuf_write_bytes(strbuf *buf, const unsigned char *p, size_t len);
 
@@ -51,12 +52,11 @@ strbuf_reset(strbuf *p)
 static inline size_t
 strbuf_add(strbuf *p, unsigned char ch)
 {
-    size_t newlen = p->len + 2;
-    if (newlen > p->cap)
-        if (!strbuf_extend(p, newlen))
-            return 0;
-
-    p->buf[p->len++] = ch;
-    p->buf[p->len] = 0;
-    return p->len;
+    if (p->len + 2 <= p->cap)
+    {
+        p->buf[p->len++] = ch;
+        p->buf[p->len] = 0;
+        return p->len;
+    }
+    return strbuf_append_ch(p, ch);
 }

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/charset.c
   ${CMAKE_SOURCE_DIR}/src/romaji.c
   ${CMAKE_SOURCE_DIR}/src/trie.c
-  ${CMAKE_SOURCE_DIR}/src/wordbuf.c
+  ${CMAKE_SOURCE_DIR}/src/strbuf.c
   ${CMAKE_SOURCE_DIR}/src/wordlist.c)
 target_include_directories(romaji PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_compile_definitions(
@@ -33,7 +33,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/romaji.c
   ${CMAKE_SOURCE_DIR}/src/rxgen.c
   ${CMAKE_SOURCE_DIR}/src/trie.c
-  ${CMAKE_SOURCE_DIR}/src/wordbuf.c
+  ${CMAKE_SOURCE_DIR}/src/strbuf.c
   ${CMAKE_SOURCE_DIR}/src/wordlist.c)
 target_include_directories(qspeed PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_compile_definitions(

--- a/src/testdir/romaji_main.c
+++ b/src/testdir/romaji_main.c
@@ -4,7 +4,7 @@
 //
 // Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
 //
-// gcc -o romaji romaji_main.c ../romaji.c ../wordbuf.c
+// gcc -o romaji romaji_main.c ../romaji.c ../strbuf.c
 
 #include <stdio.h>
 #include <string.h>

--- a/src/wordbuf.c
+++ b/src/wordbuf.c
@@ -16,9 +16,6 @@
 #define WORDBUF_DEFAULT_SIZE 64
 #define WORDBUF_MAX_SIZE     (8 * 1024 * 1024)
 
-int n_wordbuf_open = 0;  // for DEBUG
-int n_wordbuf_close = 0; // for DEBUG
-
 wordbuf *
 wordbuf_open()
 {
@@ -26,16 +23,15 @@ wordbuf_open()
     if (!p)
         return NULL;
 
-    p->len = WORDBUF_DEFAULT_SIZE;
-    p->buf = (unsigned char *)malloc(p->len);
+    p->cap = WORDBUF_DEFAULT_SIZE;
+    p->buf = (unsigned char *)malloc(p->cap);
     if (!p->buf)
     {
         free(p);
         return NULL;
     }
-    p->last = 0;
+    p->len = 0;
     p->buf[0] = '\0';
-    ++n_wordbuf_open; // for DEBUG
     return p;
 }
 
@@ -44,7 +40,6 @@ wordbuf_close(wordbuf *p)
 {
     if (p)
     {
-        ++n_wordbuf_close; // for DEBUG
         free(p->buf);
         free(p);
     }
@@ -59,7 +54,7 @@ wordbuf_extend(wordbuf *p, size_t req_len)
     if (req_len > WORDBUF_MAX_SIZE)
         return 0;
 
-    size_t newlen = p->len * 2;
+    size_t newlen = p->cap * 2;
     unsigned char *newbuf;
 
     while (req_len > newlen)
@@ -71,22 +66,16 @@ wordbuf_extend(wordbuf *p, size_t req_len)
     }
     else
     {
-        p->len = newlen;
+        p->cap = newlen;
         p->buf = newbuf;
         return req_len;
     }
 }
 
 size_t
-wordbuf_last(wordbuf *p)
-{
-    return p->last;
-}
-
-size_t
 wordbuf_append(wordbuf *p, wordbuf *q)
 {
-    return wordbuf_write_bytes(p, q->buf, q->last);
+    return wordbuf_write_bytes(p, q->buf, q->len);
 }
 
 size_t
@@ -102,14 +91,14 @@ wordbuf_cat(wordbuf *p, const unsigned char *sz)
 
     if (len > 0)
     {
-        size_t newlen = (size_t)p->last + len + 1;
+        size_t newlen = (size_t)p->len + len + 1;
 
-        if (newlen > p->len && !wordbuf_extend(p, newlen))
+        if (newlen > p->cap && !wordbuf_extend(p, newlen))
             return 0;
-        memcpy(&p->buf[p->last], sz, len + 1);
-        p->last += len;
+        memcpy(&p->buf[p->len], sz, len + 1);
+        p->len += len;
     }
-    return p->last;
+    return p->len;
 }
 
 size_t
@@ -117,18 +106,12 @@ wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len)
 {
     if (p != NULL && len > 0)
     {
-        size_t newlen = buf->last + len + 1;
-        if (newlen > buf->len && !wordbuf_extend(buf, newlen))
+        size_t newlen = buf->len + len + 1;
+        if (newlen > buf->cap && !wordbuf_extend(buf, newlen))
             return 0;
-        memcpy(&buf->buf[buf->last], p, len);
-        buf->last += len;
-        buf->buf[buf->last] = '\0';
+        memcpy(&buf->buf[buf->len], p, len);
+        buf->len += len;
+        buf->buf[buf->len] = '\0';
     }
-    return buf->last;
-}
-
-unsigned char *
-wordbuf_get(wordbuf *p)
-{
-    return p->buf;
+    return buf->len;
 }

--- a/src/wordbuf.h
+++ b/src/wordbuf.h
@@ -9,17 +9,10 @@
 typedef struct wordbuf wordbuf;
 struct wordbuf
 {
-    size_t len;  // amount of memory allocated to buf
-    size_t last; // length of the string actually stored in buf
+    size_t cap; // amount of memory allocated to buf
+    size_t len; // length of the string actually stored in buf
     unsigned char *buf;
 };
-
-extern int n_wordbuf_open;
-extern int n_wordbuf_close;
-
-#define wordbuf_len(w) wordbuf_last(w)
-#define WORDBUF_GET(w) ((w)->buf)
-#define WORDBUF_LEN(w) ((w)->last)
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,33 +20,43 @@ extern "C" {
 
 wordbuf *wordbuf_open();
 void wordbuf_close(wordbuf *p);
-size_t wordbuf_extend(wordbuf *p, size_t len);
-size_t wordbuf_last(wordbuf *p);
+size_t wordbuf_extend(wordbuf *p, size_t req_len);
 size_t wordbuf_append(wordbuf *p, wordbuf *q);
 size_t wordbuf_cat(wordbuf *p, const unsigned char *sz);
 size_t wordbuf_write_bytes(wordbuf *buf, const unsigned char *p, size_t len);
-unsigned char *wordbuf_get(wordbuf *p);
 
 #ifdef __cplusplus
 }
 #endif
 
+static inline size_t
+wordbuf_len(wordbuf *p)
+{
+    return p->len;
+}
+
+static inline unsigned char *
+wordbuf_get(wordbuf *p)
+{
+    return p->buf;
+}
+
 static inline void
 wordbuf_reset(wordbuf *p)
 {
-    p->last = 0;
+    p->len = 0;
     p->buf[0] = '\0';
 }
 
 static inline size_t
 wordbuf_add(wordbuf *p, unsigned char ch)
 {
-    size_t newlen = p->last + 2;
-    if (newlen > p->len)
+    size_t newlen = p->len + 2;
+    if (newlen > p->cap)
         if (!wordbuf_extend(p, newlen))
             return 0;
 
-    p->buf[p->last++] = ch;
-    p->buf[p->last] = 0;
-    return p->last;
+    p->buf[p->len++] = ch;
+    p->buf[p->len] = 0;
+    return p->len;
 }


### PR DESCRIPTION
## Summary

This PR refactors the dynamic buffer module `wordbuf` to `strbuf` to better reflect its general string buffer usage. It also improves field naming clarity, optimizes hot-path buffer operations, and unifies API naming conventions across the library.

## Key Changes

- **Field & Macro Refactoring**:
  - Renamed `wordbuf` struct fields: `len` -> `cap` (capacity) and `last` -> `len` (string length) to align with standard buffer conventions.
  - Replaced macros (`WORDBUF_GET`, `WORDBUF_LEN`) with type-safe `static inline` functions (`strbuf_get`, `strbuf_len`).
- **Module Renaming (`wordbuf` -> `strbuf`)**:
  - Renamed files (`src/wordbuf.[ch]` -> `src/strbuf.[ch]`) and all references across core modules, CMake scripts, and test scripts.
- **Hot Path Performance Optimization**:
  - Extracted the slow-path buffer expansion from `strbuf_add` into `strbuf_append_ch`. This keeps `strbuf_add` small and fast for inline call sites (e.g., in hot loops).
- **API Naming & Code Style Consistency**:
  - Aligned function names to follow the `strbuf_append_*` convention (`strbuf_append_str`, `strbuf_append_mem`).
  - Organized API declarations in `strbuf.h` into categorized blocks with section comments for better readability.

## Testing

- Built and verified all target executables and tests (`cmigemo`, `romaji`, `qspeed`).