### PR TITLE
refactor(mtree): rename mnode module to mtree and clean up API interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Default dictionary search order (platform-dependent):
 ## Project Structure
 
 - `include/migemo.h` — Public C API (version 1.5)
-- `src/migemo.c`, `src/rxgen.c`, `src/romaji.c`, `src/charset.c`, `src/strbuf.c`, `src/wordlist.c`, `src/mnode.c`, `src/filename.c` — Core library (`migemo` shared lib)
+- `src/migemo.c`, `src/rxgen.c`, `src/romaji.c`, `src/charset.c`, `src/strbuf.c`, `src/wordlist.c`, `src/mtree.c`, `src/filename.c` — Core library (`migemo` shared lib)
 - `src/main.c` — CLI executable (`cmigemo`)
 - `src/testdir/romaji_main.c` — Romaji conversion tool
 - `src/testdir/profile_speed.c` — qspeed benchmark tool

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(
     charset.c
     filename.c
     migemo.c
-    mnode.c
+    mtree.c
     romaji.c
     rxgen.c
     trie.c

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -61,7 +61,7 @@ load_mtree_dictionary(migemo *obj, const char *dict_file)
     FILE *fp = fopen(dict_file, "rt");
     if (!fp)
         return NULL;
-    mtree *mt = mnode_load(obj->mtree, fp, char2int, int2char);
+    mtree *mt = mtree_load(obj->mtree, fp, char2int, int2char);
     fclose(fp);
     return mt;
 }
@@ -173,7 +173,7 @@ migemo_open(const char *dict)
     if (!(obj = (migemo *)calloc(1, sizeof(migemo))))
         return obj;
     obj->enable = 0;
-    obj->mtree = mnode_open();
+    obj->mtree = mtree_open();
     obj->charset = CHARSET_NONE;
     obj->rx = rxgen_open();
     obj->roma2hira = romaji_open();
@@ -242,7 +242,7 @@ migemo_close(migemo *obj)
         if (obj->rx)
             rxgen_close(obj->rx);
         if (obj->mtree)
-            mnode_close(obj->mtree);
+            mtree_close(obj->mtree);
         free(obj);
     }
 }
@@ -275,9 +275,9 @@ add_mnode_siblings(migemo *object, mnode *pnode)
 }
 
 static void
-add_mnode_query(migemo *object, unsigned char *query)
+add_mtree_query(migemo *object, unsigned char *query)
 {
-    mnode *pnode = mnode_query(object->mtree, query);
+    mnode *pnode = mtree_query(object->mtree, query);
     if (pnode)
     {
         add_mnode_words(object, pnode->list);
@@ -296,7 +296,7 @@ add_roma(migemo *object, unsigned char *query)
     {
         unsigned char *hira = wordlist_word(hira_item);
         migemo_addword(object, hira);
-        add_mnode_query(object, hira);
+        add_mtree_query(object, hira);
 
         wordlist *kata_list = romaji_convert_all(object->hira2kata, hira);
         for (wordlist *kata_item = kata_list; kata_item;
@@ -304,7 +304,7 @@ add_roma(migemo *object, unsigned char *query)
         {
             unsigned char *kata = wordlist_word(kata_item);
             migemo_addword(object, kata);
-            add_mnode_query(object, kata);
+            add_mtree_query(object, kata);
 
             wordlist *han_list = romaji_convert_all(object->zen2han, kata);
             for (wordlist *han_item = han_list; han_item;
@@ -374,7 +374,7 @@ query_a_word(migemo *object, unsigned char *query)
     // Dictionary lookup with the query itself
     lower = malloc(len + 1);
     if (!lower)
-        add_mnode_query(object, query);
+        add_mtree_query(object, query);
     else
     {
         int i = 0, step;
@@ -391,7 +391,7 @@ query_a_word(migemo *object, unsigned char *query)
                 memcpy(&lower[i], &query[i], step);
             i += step;
         }
-        add_mnode_query(object, lower);
+        add_mtree_query(object, lower);
     }
 
     // Convert query to full-width and add to candidates
@@ -569,13 +569,3 @@ migemo_is_enable(migemo *obj)
 {
     return obj ? obj->enable : 0;
 }
-
-#if 1
-// Primarily a hidden function for debugging purposes
-EXPORTS void MIGEMO_CALLTYPE
-migemo_print(migemo *object)
-{
-    if (object)
-        mnode_print(object->mtree, NULL);
-}
-#endif

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -16,7 +16,7 @@
 #include "filename.h"
 #include "migemo.h"
 #include "migemo_struct.h"
-#include "mnode.h"
+#include "mtree.h"
 #include "romaji.h"
 #include "rxgen.h"
 #include "strbuf.h"

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -61,7 +61,7 @@ load_mtree_dictionary(migemo *obj, const char *dict_file)
     FILE *fp = fopen(dict_file, "rt");
     if (!fp)
         return NULL;
-    mtree *mt = mtree_load(obj->mtree, fp, char2int, int2char);
+    mtree *mt = mtree_load(obj->mtree, fp, char2int);
     fclose(fp);
     return mt;
 }

--- a/src/migemo_struct.h
+++ b/src/migemo_struct.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "charset.h"
-#include "mnode.h"
+#include "mtree.h"
 #include "romaji.h"
 #include "rxgen.h"
 

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -40,7 +40,6 @@ struct mtree
     mnode_arena arena;
 
     CHARSET_PROC_CHAR2INT char2int;
-    CHARSET_PROC_INT2CHAR int2char;
 };
 
 static void
@@ -268,8 +267,7 @@ mnode_balance(mnode *root)
 
 // Batch add data from a file to existing nodes.
 mtree *
-mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
-        CHARSET_PROC_INT2CHAR int2char)
+mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int)
 {
     mnode *pp = NULL;
     int mode = 0;
@@ -283,7 +281,6 @@ mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
     unsigned char *cache_tail = cache;
 
     mt->char2int = char2int;
-    mt->int2char = int2char;
 
     buf = strbuf_open();
     prevlabel = strbuf_open();
@@ -424,7 +421,6 @@ mtree_open(void)
     mtree *mt = (mtree *)calloc(1, sizeof(*mt));
     // Set the default to UTF-8.
     mt->char2int = charset_utf8_char2int;
-    mt->int2char = charset_utf8_int2char;
     return mt;
 }
 

--- a/src/mnode.c
+++ b/src/mnode.c
@@ -91,7 +91,7 @@ mnode_debug_stat(mnode *root, trie_stat *stat)
 }
 
 void
-mnode_print_stat(mtree *mt, const char *label)
+mtree_print_stat(mtree *mt, const char *label)
 {
     if (!mt || !mt->rootnode)
     {
@@ -141,35 +141,7 @@ mnode_arena_free(mnode_arena *arena)
 }
 
 void
-mnode_print_stub(mtree *mt, mnode *vp, unsigned char *p)
-{
-    static unsigned char buf[256];
-
-    if (!vp)
-        return;
-    if (!p)
-        p = &buf[0];
-    int len = mt->int2char(vp->code, p);
-    p[len] = '\0';
-    if (vp->list)
-        printf("%s (list=%p)\n", buf, vp->list);
-    if (vp->child)
-        mnode_print_stub(mt, vp->child, p + len);
-    if (vp->low)
-        mnode_print_stub(mt, vp->low, p);
-    if (vp->high)
-        mnode_print_stub(mt, vp->high, p);
-}
-
-void
-mnode_print(mtree *mt, unsigned char *p)
-{
-    if (mt && mt->rootnode)
-        mnode_print_stub(mt, mt->rootnode, p);
-}
-
-void
-mnode_close(mtree *mt)
+mtree_close(mtree *mt)
 {
     if (mt)
     {
@@ -192,7 +164,7 @@ decode_rune(mtree *mt, const unsigned char **pp)
 }
 
 static mnode *
-search_or_new_mnode(mtree *mt, strbuf *buf)
+mtree_ensure_node(mtree *mt, strbuf *buf)
 {
     // Add to the search tree once the label word is determined
     mnode **res = NULL;
@@ -296,7 +268,7 @@ mnode_balance(mnode *root)
 
 // Batch add data from a file to existing nodes.
 mtree *
-mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
+mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
         CHARSET_PROC_INT2CHAR int2char)
 {
     mnode *pp = NULL;
@@ -366,7 +338,7 @@ mnode_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
                         strbuf_add(buf, (unsigned char)ch);
                         break;
                     case '\t':
-                        pp = search_or_new_mnode(mt, buf);
+                        pp = mtree_ensure_node(mt, buf);
                         if (!pp)
                         {
                             mt = NULL;
@@ -447,7 +419,7 @@ END_MNODE_LOAD:
 }
 
 mtree *
-mnode_open(void)
+mtree_open(void)
 {
     mtree *mt = (mtree *)calloc(1, sizeof(*mt));
     // Set the default to UTF-8.
@@ -457,7 +429,7 @@ mnode_open(void)
 }
 
 mnode *
-mnode_query(mtree *mt, const unsigned char *query)
+mtree_query(mtree *mt, const unsigned char *query)
 {
     if (!mt || !mt->rootnode || !query)
         return NULL;
@@ -481,27 +453,4 @@ mnode_query(mtree *mt, const unsigned char *query)
         node = node->child;
     }
     return node;
-}
-
-static void
-mnode_traverse_stub(mnode *node, MNODE_TRAVERSE_PROC proc, void *data)
-{
-    if (node->low)
-        mnode_traverse_stub(node->low, proc, data);
-    proc(node, data);
-    if (node->child)
-        mnode_traverse_stub(node->child, proc, data);
-    if (node->high)
-        mnode_traverse_stub(node->high, proc, data);
-}
-
-void
-mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void *data)
-{
-    if (node && proc)
-    {
-        proc(node, data);
-        if (node->child)
-            mnode_traverse_stub(node->child, proc, data);
-    }
 }

--- a/src/mnode.h
+++ b/src/mnode.h
@@ -32,8 +32,7 @@ mtree *mtree_open(void);
 void mtree_close(mtree *mt);
 
 // Load dictionary & query
-mtree *mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
-        CHARSET_PROC_INT2CHAR int2char);
+mtree *mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int);
 mnode *mtree_query(mtree *mt, const unsigned char *query);
 
 // Debug & maintenance

--- a/src/mnode.h
+++ b/src/mnode.h
@@ -23,29 +23,21 @@ struct mnode
 
 typedef struct mtree mtree;
 
-// for mnode_traverse()
-typedef void (*mnode_traverse_proc)(mnode *node, void *data);
-#define MNODE_TRAVERSE_PROC mnode_traverse_proc
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-mtree *mnode_open(void);
+// Life cycle management
+mtree *mtree_open(void);
+void mtree_close(mtree *mt);
 
-mtree *mnode_load(mtree *root, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
+// Load dictionary & query
+mtree *mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int,
         CHARSET_PROC_INT2CHAR int2char);
+mnode *mtree_query(mtree *mt, const unsigned char *query);
 
-void mnode_close(mtree *p);
-
-mnode *mnode_query(mtree *node, const unsigned char *query);
-
-void mnode_traverse(mnode *node, MNODE_TRAVERSE_PROC proc, void *data);
-
-// Mainly for debugging purposes
-void mnode_print(mtree *mt, unsigned char *p);
-
-void mnode_print_stat(mtree *mt, const char *title);
+// Debug & maintenance
+void mtree_print_stat(mtree *mt, const char *title);
 
 #ifdef __cplusplus
 }

--- a/src/mtree.c
+++ b/src/mtree.c
@@ -1,6 +1,6 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// mnode.c - mnode interfaces.
+// mtree.c - Migemo tree (mtree) operations
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
@@ -12,7 +12,7 @@
 #include <string.h>
 
 #include "charset.h"
-#include "mnode.h"
+#include "mtree.h"
 #include "strbuf.h"
 #include "trie.h"
 #include "wordlist.h"

--- a/src/mtree.h
+++ b/src/mtree.h
@@ -1,6 +1,6 @@
 // vim:set ts=8 sts=4 sw=4 tw=0 et:
 //
-// mnode.h -
+// mtree.h - Migemo tree (mtree) operations
 //
 // Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 // Need to include <stdio.h>
@@ -8,6 +8,8 @@
 #pragma once
 
 #include "wordlist.h"
+
+typedef struct mtree mtree;
 
 // Tree object
 typedef struct mnode mnode;
@@ -20,8 +22,6 @@ struct mnode
     unsigned int weight;
     wordlist *list;
 };
-
-typedef struct mtree mtree;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/charset.c
   ${CMAKE_SOURCE_DIR}/src/filename.c
   ${CMAKE_SOURCE_DIR}/src/migemo.c
-  ${CMAKE_SOURCE_DIR}/src/mnode.c
+  ${CMAKE_SOURCE_DIR}/src/mtree.c
   ${CMAKE_SOURCE_DIR}/src/romaji.c
   ${CMAKE_SOURCE_DIR}/src/rxgen.c
   ${CMAKE_SOURCE_DIR}/src/trie.c

--- a/src/testdir/profile_speed.c
+++ b/src/testdir/profile_speed.c
@@ -52,7 +52,7 @@ main(int argc, char **argv)
     clock_tmp = clock();
     pmig = migemo_open(DICTDIR "/migemo-dict");
     clock_load = clock() - clock_tmp;
-    mnode_print_stat(pmig->mtree, "mtree statistics");
+    mtree_print_stat(pmig->mtree, "mtree statistics");
     if (pmig != NULL)
     {
         printf("Quering\n");


### PR DESCRIPTION
## Summary

This PR renames and refactors the `mnode` module to `mtree` to align function and file names with the primary `mtree` data structure, standardizes the API naming conventions, and removes unused code/parameters.

## Key Changes

- **API Standardisation & Renaming**:
  - Renamed `mnode_*` functions operating on `mtree` to the `mtree_*` prefix (`mtree_open`, `mtree_close`, `mtree_load`, `mtree_query`, `mtree_print_stat`).
  - Renamed internal node insertion helper to `mtree_ensure_node` for better clarity.
- **Dead Code & Parameter Cleanup**:
  - Removed unused debug and traversal procedures (`mnode_print`, `mnode_traverse`, `migemo_print`).
  - Removed the obsolete `int2char` parameter from `mtree_load` and field from `struct mtree` as string decoding is no longer required in this module.
- **Module File Renaming**:
  - Renamed `src/mnode.[ch]` to `src/mtree.[ch]` to match module responsibilities.
  - Updated all references across core library files, `CMakeLists.txt`, test programs, and `AGENTS.md`.

## Testing

- Verified build and test executables (`cmigemo`, `romaji`, `qspeed`) pass successfully.