### PR TITLE
refactor(romaji): clean up unused code, optimize buffer size, and standardize internal naming

### DIFF
--- a/src/romaji.c
+++ b/src/romaji.c
@@ -247,6 +247,64 @@ romaji_add_entry(romaji *rj, const unsigned char *key,
     return 0;
 }
 
+static void
+romanode_stat_stub(
+        romanode *node, trie_stat *stat, int sib_depth, int total_cmp)
+{
+    if (!node)
+        return;
+
+    stat->total_nodes++;
+    stat->total_sibling_depth += sib_depth;
+    if (sib_depth > stat->max_sibling_depth)
+        stat->max_sibling_depth = sib_depth;
+
+    if (node->low)
+        stat->low_count++;
+    if (node->high)
+        stat->high_count++;
+    if (node->child)
+        stat->child_count++;
+
+    if (node->value)
+    {
+        stat->wordtail_count++;
+        stat->total_node_cmp_count += total_cmp;
+        if (total_cmp > stat->max_node_cmp_count)
+            stat->max_node_cmp_count = total_cmp;
+    }
+
+    // recursive calls for low, high, and child nodes.
+    if (node->low)
+        romanode_stat_stub(node->low, stat, sib_depth + 1, total_cmp + 1);
+    if (node->high)
+        romanode_stat_stub(node->high, stat, sib_depth + 1, total_cmp + 1);
+    if (node->child)
+        romanode_stat_stub(node->child, stat, 0, total_cmp + 1);
+}
+
+static void
+romanode_stat(romaji *rj, trie_stat *stat)
+{
+    if (!stat || !rj || !rj->rootnode)
+        return;
+    memset(stat, 0, sizeof(*stat));
+    romanode_stat_stub(rj->rootnode, stat, 0, 1);
+}
+
+void
+romanode_print_stat(romaji *rj, const char *title)
+{
+    if (!rj || !rj->rootnode)
+    {
+        printf("== INVALID romanode ===\n");
+        return;
+    }
+    trie_stat stat;
+    romanode_stat(rj, &stat);
+    trie_stat_print(&stat, title);
+}
+
 typedef enum {
     MODE_KEY_WAITING = 0,
     MODE_KEY_READING = 1,
@@ -398,64 +456,6 @@ romaji_load_stub(romaji *rj, FILE *fp)
         }
     }
     return 0;
-}
-
-static void
-romanode_stat_stub(
-        romanode *node, trie_stat *stat, int sib_depth, int total_cmp)
-{
-    if (!node)
-        return;
-
-    stat->total_nodes++;
-    stat->total_sibling_depth += sib_depth;
-    if (sib_depth > stat->max_sibling_depth)
-        stat->max_sibling_depth = sib_depth;
-
-    if (node->low)
-        stat->low_count++;
-    if (node->high)
-        stat->high_count++;
-    if (node->child)
-        stat->child_count++;
-
-    if (node->value)
-    {
-        stat->wordtail_count++;
-        stat->total_node_cmp_count += total_cmp;
-        if (total_cmp > stat->max_node_cmp_count)
-            stat->max_node_cmp_count = total_cmp;
-    }
-
-    // recursive calls for low, high, and child nodes.
-    if (node->low)
-        romanode_stat_stub(node->low, stat, sib_depth + 1, total_cmp + 1);
-    if (node->high)
-        romanode_stat_stub(node->high, stat, sib_depth + 1, total_cmp + 1);
-    if (node->child)
-        romanode_stat_stub(node->child, stat, 0, total_cmp + 1);
-}
-
-static void
-romanode_stat(romaji *rj, trie_stat *stat)
-{
-    if (!stat || !rj || !rj->rootnode)
-        return;
-    memset(stat, 0, sizeof(*stat));
-    romanode_stat_stub(rj->rootnode, stat, 0, 1);
-}
-
-void
-romanode_print_stat(romaji *rj, const char *title)
-{
-    if (!rj || !rj->rootnode)
-    {
-        printf("== INVALID romanode ===\n");
-        return;
-    }
-    trie_stat stat;
-    romanode_stat(rj, &stat);
-    trie_stat_print(&stat, title);
 }
 
 /// Load the Romaji dictionary.

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -22,10 +22,8 @@
 #endif
 
 #define ROMAJI_READ_BUFSIZE     1024
-#define ROMAJI_PUSHBACK_BUFSIZE 1024
-#define ROMANODE_BLOCK_SIZE     1024
-
-// romanode interfaces
+#define ROMAJI_BLOCK_SIZE       1024
+#define ROMAJI_PUSHBACK_BUFSIZE 256
 
 typedef struct romanode romanode;
 struct romanode
@@ -43,7 +41,7 @@ struct romanode_block
 {
     romanode_block *next;
     size_t used;
-    romanode nodes[ROMANODE_BLOCK_SIZE];
+    romanode nodes[ROMAJI_BLOCK_SIZE];
 };
 
 typedef struct romanode_arena romanode_arena;
@@ -64,7 +62,7 @@ struct romaji
 static romanode *
 romanode_arena_alloc(romanode_arena *arena, unsigned int code)
 {
-    if (!arena->curr || arena->curr->used >= ROMANODE_BLOCK_SIZE)
+    if (!arena->curr || arena->curr->used >= ROMAJI_BLOCK_SIZE)
     {
         romanode_block *block =
                 (romanode_block *)calloc(1, sizeof(romanode_block));
@@ -179,8 +177,6 @@ romanode_balance(romanode *root)
     return root;
 }
 
-// romaji interfaces
-
 romaji *
 romaji_open()
 {
@@ -262,7 +258,7 @@ typedef enum {
 } load_mode;
 
 static int
-isspace_u(unsigned int code)
+romaji_isspace_u(unsigned int code)
 {
     return code < 0x80 && isspace((int)code);
 }
@@ -348,7 +344,7 @@ romaji_load_stub(romaji *rj, FILE *fp)
                         p = next;
                         next = next2;
                     }
-                    if (!isspace_u(code))
+                    if (!romaji_isspace_u(code))
                     {
                         key = p;
                         mode = MODE_KEY_READING;
@@ -356,7 +352,7 @@ romaji_load_stub(romaji *rj, FILE *fp)
                     break;
 
                 case MODE_KEY_READING:
-                    if (isspace_u(code))
+                    if (romaji_isspace_u(code))
                     {
                         key_end = p;
                         mode = MODE_VALUE_WAITING;
@@ -364,7 +360,7 @@ romaji_load_stub(romaji *rj, FILE *fp)
                     break;
 
                 case MODE_VALUE_WAITING:
-                    if (!isspace_u(code))
+                    if (!romaji_isspace_u(code))
                     {
                         value = p;
                         mode = MODE_VALUE_READING;
@@ -372,7 +368,7 @@ romaji_load_stub(romaji *rj, FILE *fp)
                     break;
 
                 case MODE_VALUE_READING:
-                    if (isspace_u(code))
+                    if (romaji_isspace_u(code))
                     {
                         value_end = p;
                         mode = MODE_REMAIN_WAITING;
@@ -380,7 +376,7 @@ romaji_load_stub(romaji *rj, FILE *fp)
                     break;
 
                 case MODE_REMAIN_WAITING:
-                    if (!isspace_u(code))
+                    if (!romaji_isspace_u(code))
                     {
                         remain = p;
                         mode = MODE_REMAIN_READING;
@@ -388,7 +384,7 @@ romaji_load_stub(romaji *rj, FILE *fp)
                     break;
 
                 case MODE_REMAIN_READING:
-                    if (isspace_u(code))
+                    if (romaji_isspace_u(code))
                     {
                         remain_end = p;
                         mode = MODE_LINE_SKIP;
@@ -483,7 +479,7 @@ romaji_load(romaji *rj, const unsigned char *filename,
 }
 
 static romanode *
-find_siblings(romaji *rj, romanode *node, unsigned int code)
+romaji_find_siblings(romaji *rj, romanode *node, unsigned int code)
 {
     if (node && node->child)
         node = node->child;
@@ -503,18 +499,18 @@ find_siblings(romaji *rj, romanode *node, unsigned int code)
 }
 
 static inline size_t
-decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
+romaji_decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
 {
     int len = proc(s, NULL);
     return len > 0 ? (size_t)len : 1;
 }
 
 static wordlist *
-add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
+romaji_add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
 {
     if (!node)
         return tail;
-    tail = add_pending_node(tail, node->low, prefix);
+    tail = romaji_add_pending_node(tail, node->low, prefix);
     if (node->value)
     {
         strbuf *w = strbuf_open();
@@ -528,8 +524,8 @@ add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
             strbuf_close(w);
         }
     }
-    tail = add_pending_node(tail, node->child, prefix);
-    tail = add_pending_node(tail, node->high, prefix);
+    tail = romaji_add_pending_node(tail, node->child, prefix);
+    tail = romaji_add_pending_node(tail, node->high, prefix);
     return tail;
 }
 
@@ -564,14 +560,14 @@ romaji_convert_all(romaji *rj, const unsigned char *src)
         if (code == 0)
             break;
 
-        node = find_siblings(rj, node, code);
+        node = romaji_find_siblings(rj, node, code);
 
         if (!node)
         {
             strbuf_append_mem(pending, prev, curr - prev);
             // Consume a code from the pending, add it to dstbuf.
             unsigned char *p = strbuf_get(pending);
-            size_t len = decode_len(rj->char2int, p);
+            size_t len = romaji_decode_len(rj->char2int, p);
             strbuf_append_mem(dstbuf, p, len);
             // Push the pending remainder to the front of srcbuf.
             size_t rem_len = strbuf_len(pending) - len;
@@ -614,7 +610,7 @@ romaji_convert_all(romaji *rj, const unsigned char *src)
         // Output all entries under the pending node.
         wordlist pendings = {0};
         if (node)
-            add_pending_node(&pendings, node->child, dstbuf);
+            romaji_add_pending_node(&pendings, node->child, dstbuf);
         list = pendings.next;
     }
 

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "charset.h"
 #include "romaji.h"
 #include "strbuf.h"
 #include "trie.h"
@@ -56,14 +55,10 @@ struct romanode_arena
 
 struct romaji
 {
-    int verbose;
-
     romanode *rootnode;
     romanode_arena arena;
 
-    unsigned char *fixvalue_xn;
-    unsigned char *fixvalue_xtu;
-    ROMAJI_PROC_CHAR2INT char2int;
+    CHARSET_PROC_CHAR2INT char2int;
 };
 
 static romanode *
@@ -193,27 +188,25 @@ romaji_open()
 }
 
 void
-romaji_close(romaji *object)
+romaji_close(romaji *rj)
 {
-    if (object)
+    if (rj)
     {
-        romanode_arena_free(&object->arena);
-        free(object->fixvalue_xn);
-        free(object->fixvalue_xtu);
-        free(object);
+        romanode_arena_free(&rj->arena);
+        free(rj);
     }
 }
 
 static int
-romaji_add_entry(romaji *object, const unsigned char *key,
+romaji_add_entry(romaji *rj, const unsigned char *key,
         const unsigned char *value, const unsigned char *remain)
 {
-    romanode **ppnode = &object->rootnode;
+    romanode **ppnode = &rj->rootnode;
     romanode *pnode = NULL;
     const unsigned char *p = key;
     while (1)
     {
-        unsigned int code = charset_decode(object->char2int, &p);
+        unsigned int code = charset_decode(rj->char2int, &p);
 
         if (code == 0)
         {
@@ -243,7 +236,7 @@ romaji_add_entry(romaji *object, const unsigned char *key,
             pnode->remain = dup_remain;
             break;
         }
-        pnode = romanode_dig(&object->arena, ppnode, code);
+        pnode = romanode_dig(&rj->arena, ppnode, code);
         if (!pnode)
             return 5; // Allocation error.
 
@@ -275,7 +268,7 @@ isspace_u(unsigned int code)
 }
 
 static int
-romaji_load_stub(romaji *object, FILE *fp)
+romaji_load_stub(romaji *rj, FILE *fp)
 {
     unsigned char buf[ROMAJI_READ_BUFSIZE];
     while (1)
@@ -305,8 +298,8 @@ romaji_load_stub(romaji *object, FILE *fp)
         for (unsigned char *p = buf; p < end; p = next)
         {
             next = p;
-            unsigned int code = charset_decode(
-                    object->char2int, (const unsigned char **)&next);
+            unsigned int code =
+                    charset_decode(rj->char2int, (const unsigned char **)&next);
 
             // End of the line.
             if (code == '\n' || code == 0)
@@ -329,7 +322,7 @@ romaji_load_stub(romaji *object, FILE *fp)
                 *value_end = '\0';
                 if (remain_end)
                     *remain_end = '\0';
-                int err = romaji_add_entry(object, key, value, remain);
+                int err = romaji_add_entry(rj, key, value, remain);
                 if (err > 1)
                     return err * 10 + 4;
                 break;
@@ -344,8 +337,8 @@ romaji_load_stub(romaji *object, FILE *fp)
                         // starting with `#`; if it starts with only `#`, it is
                         // treated as a comment line.
                         unsigned char *next2 = next;
-                        unsigned int code2 = charset_decode(object->char2int,
-                                (const unsigned char **)&next2);
+                        unsigned int code2 = charset_decode(
+                                rj->char2int, (const unsigned char **)&next2);
                         if (code2 != '#')
                         {
                             next = end;
@@ -448,68 +441,54 @@ romanode_stat_stub(
 }
 
 static void
-romanode_stat(romaji *obj, trie_stat *stat)
+romanode_stat(romaji *rj, trie_stat *stat)
 {
-    if (!stat || !obj || !obj->rootnode)
+    if (!stat || !rj || !rj->rootnode)
         return;
     memset(stat, 0, sizeof(*stat));
-    romanode_stat_stub(obj->rootnode, stat, 0, 1);
+    romanode_stat_stub(rj->rootnode, stat, 0, 1);
 }
 
 void
-romanode_print_stat(romaji *obj, const char *title)
+romanode_print_stat(romaji *rj, const char *title)
 {
-    if (!obj || !obj->rootnode)
+    if (!rj || !rj->rootnode)
     {
         printf("== INVALID romanode ===\n");
         return;
     }
     trie_stat stat;
-    romanode_stat(obj, &stat);
+    romanode_stat(rj, &stat);
     trie_stat_print(&stat, title);
 }
 
 /// Load the Romaji dictionary.
-/// @param object Romaji object
+/// @param rj Romaji object
 /// @param filename Dictionary filename
 /// @return 0 on success, non-zero on failure.
 int
-romaji_load(romaji *object, const unsigned char *filename,
+romaji_load(romaji *rj, const unsigned char *filename,
         CHARSET_PROC_CHAR2INT char2int)
 {
-    if (!object || !filename)
+    if (!rj || !filename)
         return -1;
-    object->char2int = char2int;
+    rj->char2int = char2int;
     FILE *fp = fopen(filename, "rt");
     if (!fp)
         return -1;
-    int result = romaji_load_stub(object, fp);
+    int result = romaji_load_stub(rj, fp);
     fclose(fp);
-    object->rootnode = romanode_balance(object->rootnode);
+    rj->rootnode = romanode_balance(rj->rootnode);
     return result;
 }
 
-void
-romaji_setproc_char2int(romaji *object, ROMAJI_PROC_CHAR2INT proc)
-{
-    if (object)
-        object->char2int = proc;
-}
-
-void
-romaji_set_verbose(romaji *object, int level)
-{
-    if (object)
-        object->verbose = level;
-}
-
 static romanode *
-find_siblings(romaji *object, romanode *node, unsigned int code)
+find_siblings(romaji *rj, romanode *node, unsigned int code)
 {
     if (node && node->child)
         node = node->child;
     if (!node)
-        node = object->rootnode;
+        node = rj->rootnode;
 
     while (node)
     {
@@ -555,7 +534,7 @@ add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
 }
 
 wordlist *
-romaji_convert_all(romaji *object, const unsigned char *src)
+romaji_convert_all(romaji *rj, const unsigned char *src)
 {
     wordlist *list = NULL;
     unsigned char *srcbuf = NULL;
@@ -581,18 +560,18 @@ romaji_convert_all(romaji *object, const unsigned char *src)
     {
         const unsigned char *prev = curr;
         unsigned int code =
-                charset_decode(object->char2int, (const unsigned char **)&curr);
+                charset_decode(rj->char2int, (const unsigned char **)&curr);
         if (code == 0)
             break;
 
-        node = find_siblings(object, node, code);
+        node = find_siblings(rj, node, code);
 
         if (!node)
         {
             strbuf_append_mem(pending, prev, curr - prev);
             // Consume a code from the pending, add it to dstbuf.
             unsigned char *p = strbuf_get(pending);
-            size_t len = decode_len(object->char2int, p);
+            size_t len = decode_len(rj->char2int, p);
             strbuf_append_mem(dstbuf, p, len);
             // Push the pending remainder to the front of srcbuf.
             size_t rem_len = strbuf_len(pending) - len;

--- a/src/romaji.h
+++ b/src/romaji.h
@@ -11,24 +11,21 @@
 
 typedef struct romaji romaji;
 
-typedef int (*romaji_proc_char2int)(const unsigned char *, unsigned int *);
-#define ROMAJI_PROC_CHAR2INT romaji_proc_char2int
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// Life cycle management
 romaji *romaji_open();
-void romaji_close(romaji *object);
-int romaji_load(romaji *object, const unsigned char *filename,
+void romaji_close(romaji *rj);
+
+// Load and convert
+int romaji_load(romaji *rj, const unsigned char *filename,
         CHARSET_PROC_CHAR2INT char2int);
+wordlist *romaji_convert_all(romaji *rj, const unsigned char *src);
 
-void romaji_setproc_char2int(romaji *object, ROMAJI_PROC_CHAR2INT proc);
-void romaji_set_verbose(romaji *object, int level);
-
-void romanode_print_stat(romaji *obj, const char *title);
-
-wordlist *romaji_convert_all(romaji *object, const unsigned char *src);
+// Debug & maintenance
+void romanode_print_stat(romaji *rj, const char *title);
 
 #ifdef __cplusplus
 }

--- a/src/testdir/romaji_main.c
+++ b/src/testdir/romaji_main.c
@@ -28,10 +28,10 @@
 #endif
 
 void
-query_one(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han,
+query_one(romaji *rj, romaji *hira2kata, romaji *han2zen, romaji *zen2han,
         char *buf)
 {
-    wordlist *hira = romaji_convert_all(object, buf);
+    wordlist *hira = romaji_convert_all(rj, buf);
     for (wordlist *p = hira; p; p = wordlist_next(p))
     {
         printf("  hira=%s\n", wordlist_word(p));
@@ -55,7 +55,7 @@ query_one(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han,
 }
 
 void
-query_loop(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
+query_loop(romaji *rj, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
 {
     char buf[256], *ans;
 
@@ -70,21 +70,20 @@ query_loop(romaji *object, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
         // Replace newline with NUL character
         if ((ans = strchr(buf, '\n')) != NULL)
             *ans = '\0';
-        query_one(object, hira2kata, han2zen, zen2han, buf);
+        query_one(rj, hira2kata, han2zen, zen2han, buf);
     }
 }
 
 int
 main(int argc, char **argv)
 {
-    romaji *object, *hira2kata, *han2zen, *zen2han;
+    romaji *rj, *hira2kata, *han2zen, *zen2han;
     char *word = NULL;
 
-    object = romaji_open();
+    rj = romaji_open();
     hira2kata = romaji_open();
     han2zen = romaji_open();
     zen2han = romaji_open();
-    romaji_set_verbose(zen2han, 1);
 
     while (*++argv)
     {
@@ -94,11 +93,11 @@ main(int argc, char **argv)
             word = *++argv;
     }
 
-    if (object && hira2kata && han2zen && zen2han)
+    if (rj && hira2kata && han2zen && zen2han)
     {
         int retval = 0;
 
-        retval = romaji_load(object, DICT_ROMA2HIRA, charset_utf8_char2int);
+        retval = romaji_load(rj, DICT_ROMA2HIRA, charset_utf8_char2int);
         printf("romaji_load(%s)=%d\n", DICT_ROMA2HIRA, retval);
         retval = romaji_load(hira2kata, DICT_HIRA2KATA, charset_utf8_char2int);
         printf("romaji_load(%s)=%d\n", DICT_HIRA2KATA, retval);
@@ -107,17 +106,17 @@ main(int argc, char **argv)
         retval = romaji_load(zen2han, DICT_ZEN2HAN, charset_utf8_char2int);
         printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
         if (word)
-            query_one(object, hira2kata, han2zen, zen2han, word);
+            query_one(rj, hira2kata, han2zen, zen2han, word);
         else
-            query_loop(object, hira2kata, han2zen, zen2han);
+            query_loop(rj, hira2kata, han2zen, zen2han);
     }
 
     if (han2zen)
         romaji_close(han2zen);
     if (hira2kata)
         romaji_close(hira2kata);
-    if (object)
-        romaji_close(object);
+    if (rj)
+        romaji_close(rj);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

This PR refactors the `romaji` module to remove unused legacy fields/APIs, optimize internal buffer sizes, prefix file-local helper functions, and align module code layout and structure.

## Key Changes

- **API & Dead Code Cleanup**:
  - Removed unused fields (`verbose`, `fixvalue_xn`, `fixvalue_xtu`) from `struct romaji`.
  - Removed obsolete APIs and typedefs (`romaji_set_verbose`, `romaji_setproc_char2int`, `ROMAJI_PROC_CHAR2INT`).
- **Buffer & Macro Optimization**:
  - Reduced `ROMAJI_PUSHBACK_BUFSIZE` from 1024 to 256 bytes for better memory efficiency during conversion.
  - Renamed `ROMANODE_BLOCK_SIZE` to `ROMAJI_BLOCK_SIZE` to standardize macro naming.
- **Internal Helper Encapsulation & Code Layout**:
  - Prefixed file-local functions with `romaji_` (`romaji_isspace_u`, `romaji_find_siblings`, `romaji_decode_len`, `romaji_add_pending_node`).
  - Standardized receiver argument names from `object` to `rj` across functions.
  - Moved `romanode_stat` functions above `romaji_load_stub` so dictionary loading functions are placed contiguously.
  - Organized `romaji.h` with section comments for consistent header style across modules.

## Testing

- Verified build and test executables (`cmigemo`, `romaji_main`, etc.) pass successfully.