### PR TITLE
refactor(build): use PROJECT_ variables instead of CMAKE_ globals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@ option(BUILD_TESTING "Build tests" ON)
 #------------------------------------------------------------------------------
 
 include(GNUInstallDirs)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 
 #------------------------------------------------------------------------------
 
@@ -54,8 +54,6 @@ if(MSVC)
   add_compile_options(/utf-8 /W3 /wd4710 /wd4711 /wd5045)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 #------------------------------------------------------------------------------
 

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -3,17 +3,17 @@
 add_executable(
   romaji
   romaji_main.c
-  ${CMAKE_SOURCE_DIR}/src/charset.c
-  ${CMAKE_SOURCE_DIR}/src/romaji.c
-  ${CMAKE_SOURCE_DIR}/src/trie.c
-  ${CMAKE_SOURCE_DIR}/src/strbuf.c
-  ${CMAKE_SOURCE_DIR}/src/wordlist.c)
+  ${PROJECT_SOURCE_DIR}/src/charset.c
+  ${PROJECT_SOURCE_DIR}/src/romaji.c
+  ${PROJECT_SOURCE_DIR}/src/trie.c
+  ${PROJECT_SOURCE_DIR}/src/strbuf.c
+  ${PROJECT_SOURCE_DIR}/src/wordlist.c)
 target_include_directories(
   romaji
   PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src/include)
 target_compile_definitions(
   romaji
-  PRIVATE DICTDIR="${CMAKE_BINARY_DIR}/dict/utf-8" _DEBUG)
+  PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8" _DEBUG)
 
 if(MSVC)
   set_target_properties(
@@ -28,21 +28,21 @@ endif()
 add_executable(
   qspeed
   profile_speed.c
-  ${CMAKE_SOURCE_DIR}/src/charset.c
-  ${CMAKE_SOURCE_DIR}/src/filename.c
-  ${CMAKE_SOURCE_DIR}/src/migemo.c
-  ${CMAKE_SOURCE_DIR}/src/mtree.c
-  ${CMAKE_SOURCE_DIR}/src/romaji.c
-  ${CMAKE_SOURCE_DIR}/src/rxgen.c
-  ${CMAKE_SOURCE_DIR}/src/trie.c
-  ${CMAKE_SOURCE_DIR}/src/strbuf.c
-  ${CMAKE_SOURCE_DIR}/src/wordlist.c)
+  ${PROJECT_SOURCE_DIR}/src/charset.c
+  ${PROJECT_SOURCE_DIR}/src/filename.c
+  ${PROJECT_SOURCE_DIR}/src/migemo.c
+  ${PROJECT_SOURCE_DIR}/src/mtree.c
+  ${PROJECT_SOURCE_DIR}/src/romaji.c
+  ${PROJECT_SOURCE_DIR}/src/rxgen.c
+  ${PROJECT_SOURCE_DIR}/src/trie.c
+  ${PROJECT_SOURCE_DIR}/src/strbuf.c
+  ${PROJECT_SOURCE_DIR}/src/wordlist.c)
 target_include_directories(
   qspeed
   PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src/include)
 target_compile_definitions(
   qspeed
-  PRIVATE DICTDIR="${CMAKE_BINARY_DIR}/dict/utf-8" _DEBUG)
+  PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8" _DEBUG)
 
 if(MSVC)
   set_target_properties(
@@ -70,7 +70,7 @@ if(GPROF_EXECUTABLE AND CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     COMMAND ${CMAKE_COMMAND} -E echo "Generating profile.log..."
     COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/copy_gmon.cmake"
     COMMAND ${GPROF_EXECUTABLE} $<TARGET_FILE:qspeed> gmon.out > profile.log
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     DEPENDS qspeed
     COMMENT "Running qspeed benchmark and generating profile.log")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,13 +2,13 @@ add_executable(test1 main.c test1.c)
 
 target_link_libraries(test1 PRIVATE migemo)
 
-target_include_directories(test1 PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(test1 PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
 target_compile_definitions(
   test1
   PRIVATE
     TEST_DICTDIR_MIGEMO="${CMAKE_CURRENT_SOURCE_DIR}/test1"
-    TEST_DICTDIR_ROMA2HIRA="${CMAKE_SOURCE_DIR}/dict")
+    TEST_DICTDIR_ROMA2HIRA="${PROJECT_SOURCE_DIR}/dict")
 
 #------------------------------------------------------------------------------
 
@@ -17,7 +17,7 @@ add_test(NAME test_migemo1 COMMAND test1)
 # Configuration for loading test dictionaries
 set_tests_properties(
   test_migemo1
-  PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
+  PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description
This PR updates `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` to their `PROJECT_SOURCE_DIR` and `PROJECT_BINARY_DIR` equivalents across the CMake build configuration. It also removes a redundant `include_directories()` call in the root `CMakeLists.txt`.

### Motivation & Context
When this repository is included in a parent CMake project (e.g., via `add_subdirectory()` or `FetchContent`), using top-level `CMAKE_` global variables causes path resolution issues and pollutes the root build directory. Switching to `PROJECT_` variables scopes the paths correctly to this project.

### Changes
- Updated output directories in `CMakeLists.txt` to use `PROJECT_BINARY_DIR`.
- Updated source and build paths in `src/testdir/CMakeLists.txt` and `test/CMakeLists.txt` to use `PROJECT_SOURCE_DIR` and `PROJECT_BINARY_DIR`.
- Cleaned up redundant global `include_directories()` in the root `CMakeLists.txt`.