### PR TITLE
feat(wasm): add WebAssembly build support and JS wrapper

### DIFF
--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -1,0 +1,41 @@
+name: CI on WebAssembly
+
+on:
+  workflow_call:
+
+jobs:
+
+  build:
+
+    name: Build
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Set up Emscripten SDK
+      uses: mymindstorm/setup-emsdk@v14
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Build
+      run: |
+        emcmake cmake -B build-wasm -DBUILD_DICT=OFF -DCMAKE_BUILD_TYPE=Release
+        cmake --build build-wasm
+
+    - name: Test
+      run: node wasm/test/test.js
+
+    - name: Upload the package
+      uses: actions/upload-artifact@v4
+      with:
+        path: |
+          wasm/migemo_wasm.wasm
+          wasm/migemo_wasm.js
+          wasm/index.js
+          wasm/library.js

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Emscripten SDK
-      uses: mymindstorm/setup-emsdk@v14
+      uses: mymindstorm/setup-emsdk@v16
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
-        node-version: '20'
+        node-version: 'latest'
 
     - name: Build
       run: |
@@ -31,9 +31,20 @@ jobs:
     - name: Test
       run: node wasm/test/test.js
 
+    - name: List files in build
+      run: tree -Fh build-wasm
+
+    - name: Get Version
+      id: get_version
+      run: |
+        VERSION=$(grep -w MIGEMO_VERSION build-wasm/src/include/migemo.h | cut -d '"' -f 2)
+        PRERELEASE=$(grep -w MIGEMO_VERSION_PRERELEASE build-wasm/src/include/migemo.h | cut -d '"' -f 2)
+        echo "version=${VERSION}${PRERELEASE}" >> $GITHUB_OUTPUT
+
     - name: Upload the package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
+        name: cmigemo-${{ steps.get_version.outputs.version }}-wasm
         path: |
           wasm/migemo_wasm.wasm
           wasm/migemo_wasm.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,8 @@ jobs:
     name: Windows (MSYS2)
     uses: ./.github/workflows/ci-windows-msys2.yml
     secrets: inherit
+
+  wasm:
+    name: WebAssembly
+    uses: ./.github/workflows/ci-wasm.yml
+    secrets: inherit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ if(BUILD_TESTING)
   add_subdirectory(test)
   add_subdirectory(src/testdir)
 endif()
+if(EMSCRIPTEN)
+  add_subdirectory(wasm)
+endif()
 
 #------------------------------------------------------------------------------
 

--- a/wasm/.gitignore
+++ b/wasm/.gitignore
@@ -1,0 +1,2 @@
+migemo_wasm.js
+migemo_wasm.wasm

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -12,7 +12,11 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/strbuf.c
   ${CMAKE_SOURCE_DIR}/src/wordlist.c)
 
-target_include_directories(migemo_wasm PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(
+  migemo_wasm
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/src/include)
 
 set_target_properties(
   migemo_wasm

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.16)
+
+add_executable(
+  migemo_wasm
+  ${CMAKE_SOURCE_DIR}/src/charset.c
+  ${CMAKE_SOURCE_DIR}/src/filename.c
+  ${CMAKE_SOURCE_DIR}/src/migemo.c
+  ${CMAKE_SOURCE_DIR}/src/mtree.c
+  ${CMAKE_SOURCE_DIR}/src/romaji.c
+  ${CMAKE_SOURCE_DIR}/src/rxgen.c
+  ${CMAKE_SOURCE_DIR}/src/trie.c
+  ${CMAKE_SOURCE_DIR}/src/strbuf.c
+  ${CMAKE_SOURCE_DIR}/src/wordlist.c)
+
+target_include_directories(migemo_wasm PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
+set_target_properties(
+  migemo_wasm
+  PROPERTIES OUTPUT_NAME "migemo_wasm" SUFFIX ".js")
+
+target_link_options(
+  migemo_wasm
+  PRIVATE
+    "--js-library"
+    "${CMAKE_CURRENT_SOURCE_DIR}/library.js"
+    "-sEXPORTED_FUNCTIONS=['_migemo_open','_migemo_close','_migemo_query','_migemo_release','_migemo_load','_migemo_is_enable','_malloc','_free']"
+    "-sEXPORTED_RUNTIME_METHODS=['FS','ccall','cwrap','UTF8ToString','allocate','ALLOC_NORMAL']"
+    "-sMODULARIZE=1"
+    "-sEXPORT_NAME='createMigemoModule'"
+    "-sEXPORT_ES6=1"
+    "-sENVIRONMENT=web,node"
+    "-sALLOW_MEMORY_GROWTH=1")
+
+add_custom_command(
+  TARGET migemo_wasm
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:migemo_wasm>/migemo_wasm.js
+    ${CMAKE_CURRENT_SOURCE_DIR}/migemo_wasm.js
+  COMMAND
+    ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:migemo_wasm>/migemo_wasm.wasm
+    ${CMAKE_CURRENT_SOURCE_DIR}/migemo_wasm.wasm)

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -1,0 +1,241 @@
+let moduleInstance = null;
+let migemoInstance = 0;
+
+/**
+ * Gets the Emscripten module factory function dynamically.
+ * @returns {Promise<Function>}
+ */
+async function getModuleFactory() {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.createMigemoModule === 'function') {
+    return globalThis.createMigemoModule;
+  }
+  try {
+    const mod = await import('./migemo_wasm.js');
+    return mod.default || mod.createMigemoModule || mod;
+  } catch (e) {
+    try {
+      const mod = await import('../build-wasm/bin/migemo_wasm.js');
+      return mod.default || mod.createMigemoModule || mod;
+    } catch (e2) {
+      try {
+        const mod = await import('../build/bin/migemo_wasm.js');
+        return mod.default || mod.createMigemoModule || mod;
+      } catch (e3) {
+        throw new Error("Unable to locate createMigemoModule factory function. Ensure migemo_wasm.js is built.");
+      }
+    }
+  }
+}
+
+/**
+ * Normalizes user options into a standard object structure.
+ * @param {Object|string|Uint8Array|ArrayBuffer} options
+ * @returns {Object}
+ */
+function normalizeOptions(options) {
+  if (typeof options === 'string') {
+    return { dictPath: options };
+  }
+  if (options instanceof Uint8Array || options instanceof ArrayBuffer) {
+    return { dictData: options };
+  }
+  if (typeof options === 'object' && options !== null) {
+    return { ...options };
+  }
+  return {};
+}
+
+/**
+ * Ensures directory structure exists in Emscripten Virtual File System.
+ * @param {Object} FS
+ * @param {string} filePath
+ */
+function ensureDirectory(FS, filePath) {
+  const parts = filePath.split('/').filter(Boolean);
+  let currentPath = '';
+  for (let i = 0; i < parts.length - 1; i++) {
+    currentPath += '/' + parts[i];
+    try {
+      FS.mkdir(currentPath);
+    } catch (e) {
+      // Ignore EEXIST
+    }
+  }
+}
+
+/**
+ * Initializes C/Migemo WebAssembly module and loads dictionary.
+ * @param {Object|string|Uint8Array|ArrayBuffer} options
+ * @returns {Promise<number>} Returns the C pointer singleton for the Migemo instance.
+ */
+export async function init(options = {}) {
+  const opts = normalizeOptions(options);
+
+  // Close previous C instance if active to prevent memory leaks
+  if (migemoInstance) {
+    close();
+  }
+
+  // Load Emscripten module if not yet loaded
+  if (!moduleInstance) {
+    let factory = opts.createMigemoModule;
+    if (!factory) {
+      factory = await getModuleFactory();
+    }
+    const defaultModuleOpts = {
+      locateFile: (path, scriptDirectory) => {
+        if (scriptDirectory) return scriptDirectory + path;
+        return path;
+      }
+    };
+    moduleInstance = await factory({ ...defaultModuleOpts, ...opts.moduleOpts });
+  }
+
+  const FS = moduleInstance.FS;
+  let dictPath = opts.dictPath || null;
+
+  // Handle options.dictData
+  if (opts.dictData) {
+    const data = opts.dictData instanceof Uint8Array ? opts.dictData : new Uint8Array(opts.dictData);
+    dictPath = opts.dictPath || '/migemo-dict';
+
+    ensureDirectory(FS, dictPath);
+
+    try {
+      FS.unlink(dictPath);
+    } catch (e) {
+      // Ignore ENOENT
+    }
+
+    if (typeof FS.createDataFile === 'function') {
+      const lastSlash = dictPath.lastIndexOf('/');
+      const parentDir = lastSlash > 0 ? dictPath.substring(0, lastSlash) : '/';
+      const fileName = lastSlash >= 0 ? dictPath.substring(lastSlash + 1) : dictPath;
+      try {
+        FS.createDataFile(parentDir, fileName, data, true, true, true);
+      } catch (e) {
+        // Fallback to FS.writeFile
+        FS.writeFile(dictPath, data);
+      }
+    } else {
+      FS.writeFile(dictPath, data);
+    }
+  }
+
+  // Handle options.subdicts
+  if (opts.subdicts && typeof opts.subdicts === 'object') {
+    const baseDir = dictPath ? (dictPath.substring(0, dictPath.lastIndexOf('/')) || '/') : '/';
+    const standardNames = {
+      roma2hira: 'roma2hira.dat',
+      hira2kata: 'hira2kata.dat',
+      han2zen: 'han2zen.dat',
+      zen2han: 'zen2han.dat'
+    };
+
+    for (const [key, val] of Object.entries(opts.subdicts)) {
+      if (val instanceof Uint8Array || val instanceof ArrayBuffer) {
+        const fileName = standardNames[key] || (key.endsWith('.dat') ? key : `${key}.dat`);
+        const subPath = baseDir === '/' ? `/${fileName}` : `${baseDir}/${fileName}`;
+        const subData = val instanceof Uint8Array ? val : new Uint8Array(val);
+
+        ensureDirectory(FS, subPath);
+        try { FS.unlink(subPath); } catch (e) {}
+        FS.writeFile(subPath, subData);
+      }
+    }
+  }
+
+  const migemoOpen = moduleInstance.cwrap('migemo_open', 'number', ['string']);
+  migemoInstance = migemoOpen(dictPath);
+
+  if (!migemoInstance) {
+    throw new Error(`Failed to initialize Migemo with dictPath: ${dictPath}`);
+  }
+
+  return migemoInstance;
+}
+
+/**
+ * Converts input query string into a JavaScript RegExp object.
+ * @param {string} pattern
+ * @returns {RegExp}
+ */
+export function query(pattern) {
+  if (!migemoInstance || !moduleInstance) {
+    throw new Error("Migemo is not initialized. Call init() first.");
+  }
+
+  const migemoQuery = moduleInstance.cwrap('migemo_query', 'number', ['number', 'string']);
+  const migemoRelease = moduleInstance.cwrap('migemo_release', 'void', ['number', 'number']);
+
+  const resPtr = migemoQuery(migemoInstance, pattern);
+  if (!resPtr) {
+    return new RegExp(pattern);
+  }
+
+  const resStr = moduleInstance.UTF8ToString(resPtr);
+  migemoRelease(migemoInstance, resPtr);
+
+  return new RegExp(resStr);
+}
+
+/**
+ * Closes and frees the active Migemo instance pointer.
+ */
+export function close() {
+  if (migemoInstance && moduleInstance) {
+    const migemoClose = moduleInstance.cwrap('migemo_close', 'void', ['number']);
+    migemoClose(migemoInstance);
+    migemoInstance = 0;
+  }
+}
+
+/**
+ * Checks whether dictionary is loaded and enabled.
+ * @returns {boolean}
+ */
+export function isEnable() {
+  if (!migemoInstance || !moduleInstance) return false;
+  const migemoIsEnable = moduleInstance.cwrap('migemo_is_enable', 'number', ['number']);
+  return Boolean(migemoIsEnable(migemoInstance));
+}
+
+/**
+ * Loads an additional dictionary file into the active instance.
+ * @param {number} dictId
+ * @param {string} dictPath
+ * @returns {number}
+ */
+export function load(dictId, dictPath) {
+  if (!migemoInstance || !moduleInstance) {
+    throw new Error("Migemo is not initialized. Call init() first.");
+  }
+  const migemoLoad = moduleInstance.cwrap('migemo_load', 'number', ['number', 'number', 'string']);
+  return migemoLoad(migemoInstance, dictId, dictPath);
+}
+
+/**
+ * Returns the underlying Emscripten module instance.
+ * @returns {Object|null}
+ */
+export function getModule() {
+  return moduleInstance;
+}
+
+/**
+ * Returns the active C Migemo pointer singleton.
+ * @returns {number}
+ */
+export function getInstance() {
+  return migemoInstance;
+}
+
+export default {
+  init,
+  query,
+  close,
+  isEnable,
+  load,
+  getModule,
+  getInstance
+};

--- a/wasm/library.js
+++ b/wasm/library.js
@@ -1,0 +1,12 @@
+addToLibrary({
+  $ALLOC_NORMAL: 0,
+  $allocate: function(slab, allocator) {
+    var ptr = _malloc(slab.length);
+    if (typeof HEAPU8 !== 'undefined') {
+      HEAPU8.set(slab, ptr);
+    } else if (typeof Module !== 'undefined' && Module.HEAPU8) {
+      Module.HEAPU8.set(slab, ptr);
+    }
+    return ptr;
+  }
+});

--- a/wasm/test/index.html
+++ b/wasm/test/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>C/Migemo WebAssembly Demo & Verification</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      max-width: 800px;
+      margin: 20px auto;
+      padding: 0 20px;
+      line-height: 1.6;
+    }
+    .card {
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 20px;
+    }
+    input[type="text"] {
+      width: 100%;
+      padding: 8px;
+      font-size: 16px;
+      box-sizing: border-box;
+      margin-top: 8px;
+      margin-bottom: 8px;
+    }
+    pre {
+      background: #f4f4f4;
+      padding: 12px;
+      border-radius: 4px;
+      overflow-x: auto;
+    }
+    .status {
+      font-weight: bold;
+      color: #2b78e4;
+    }
+    .success {
+      color: #2e7d32;
+    }
+  </style>
+</head>
+<body>
+  <h1>C/Migemo WebAssembly Demo</h1>
+
+  <div class="card">
+    <h2>1. Initialization</h2>
+    <p>Status: <span id="status" class="status">Not Initialized</span></p>
+    <button id="initBufferBtn">Init with ArrayBuffer (dictData)</button>
+    <button id="initOpfsBtn">Init with OPFS / Virtual FS (dictPath)</button>
+  </div>
+
+  <div class="card">
+    <h2>2. Incremental Search Query</h2>
+    <label for="searchInput">Enter Romaji Query (e.g. <code>ak</code>, <code>tokyo</code>, <code>n</code>):</label>
+    <input type="text" id="searchInput" placeholder="Type query here..." disabled>
+
+    <h3>Generated RegExp:</h3>
+    <pre id="regexOutput">N/A</pre>
+
+    <h3>Test Matches:</h3>
+    <div id="matchOutput">-</div>
+  </div>
+
+  <script type="module">
+    import { init, query, isEnable, close, getModule } from '../index.js';
+
+    const statusEl = document.getElementById('status');
+    const searchInput = document.getElementById('searchInput');
+    const regexOutput = document.getElementById('regexOutput');
+    const matchOutput = document.getElementById('matchOutput');
+
+    // Minimal embedded dictionary for browser demo if external dict is not fetched
+    const sampleDictText = "あか\t赤\t紅\t朱\nあけ\t明\nあき\t秋\nあく\t悪\n";
+    const sampleDictBuffer = new TextEncoder().encode(sampleDictText);
+
+    document.getElementById('initBufferBtn').addEventListener('click', async () => {
+      try {
+        statusEl.textContent = 'Initializing with dictData Uint8Array...';
+        await init({
+          dictData: sampleDictBuffer,
+          dictPath: '/memfs/migemo-dict'
+        });
+        statusEl.textContent = 'Initialized successfully with ArrayBuffer!';
+        statusEl.className = 'status success';
+        searchInput.disabled = false;
+        runQuery();
+      } catch (err) {
+        statusEl.textContent = 'Init Error: ' + err.message;
+      }
+    });
+
+    document.getElementById('initOpfsBtn').addEventListener('click', async () => {
+      try {
+        statusEl.textContent = 'Initializing with OPFS / Virtual FS dictPath...';
+
+        // Write to Virtual FS / WASFS
+        const mod = getModule();
+        if (mod) {
+          try { mod.FS.mkdirTree('/opfs'); } catch(e){}
+          mod.FS.writeFile('/opfs/migemo-dict', sampleDictBuffer);
+        }
+
+        await init({ dictPath: '/opfs/migemo-dict' });
+        statusEl.textContent = 'Initialized successfully with dictPath (/opfs/migemo-dict)!';
+        statusEl.className = 'status success';
+        searchInput.disabled = false;
+        runQuery();
+      } catch (err) {
+        statusEl.textContent = 'Init Error: ' + err.message;
+      }
+    });
+
+    function runQuery() {
+      const val = searchInput.value || 'ak';
+      if (!isEnable()) return;
+      try {
+        const rx = query(val);
+        regexOutput.textContent = rx.toString();
+
+        const candidates = ['赤', '明', '秋', '悪', 'ak', 'tokyo', '東京'];
+        const matches = candidates.filter(c => rx.test(c));
+        matchOutput.innerHTML = `<strong>Candidates tested:</strong> ${candidates.join(', ')}<br><strong>Matched:</strong> ${matches.join(', ')}`;
+      } catch (e) {
+        regexOutput.textContent = 'Query Error: ' + e.message;
+      }
+    }
+
+    searchInput.addEventListener('input', runQuery);
+  </script>
+</body>
+</html>

--- a/wasm/test/test.js
+++ b/wasm/test/test.js
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { init, query, close, isEnable, load, getModule, getInstance } from '../index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '../../');
+
+async function runTests() {
+  console.log('--- Starting WASM Migemo Tests ---');
+
+  // Load sample dictionary files
+  const dictDataPath = path.join(rootDir, 'test/test1/migemo-dict');
+  const roma2hiraPath = path.join(rootDir, 'dict/roma2hira.dat');
+  const hira2kataPath = path.join(rootDir, 'dict/hira2kata.dat');
+  const han2zenPath = path.join(rootDir, 'dict/han2zen.dat');
+  const zen2hanPath = path.join(rootDir, 'dict/zen2han.dat');
+
+  const dictBuffer = fs.readFileSync(dictDataPath);
+  const roma2hiraBuf = fs.readFileSync(roma2hiraPath);
+  const hira2kataBuf = fs.readFileSync(hira2kataPath);
+  const han2zenBuf = fs.readFileSync(han2zenPath);
+  const zen2hanBuf = fs.readFileSync(zen2hanPath);
+
+  // Test 1: Initialize with dictData Buffer and subdicts Buffers
+  console.log('Test 1: Initialize with dictData Buffer & subdicts');
+  const instance1 = await init({
+    dictData: dictBuffer,
+    dictPath: '/test-dict/migemo-dict',
+    subdicts: {
+      roma2hira: roma2hiraBuf,
+      hira2kata: hira2kataBuf,
+      han2zen: han2zenBuf,
+      zen2han: zen2hanBuf
+    }
+  });
+
+  assert.ok(instance1 > 0, 'Instance pointer should be a positive number');
+  assert.strictEqual(getInstance(), instance1, 'getInstance() should match active handle');
+  assert.strictEqual(isEnable(), true, 'isEnable() should be true');
+
+  // Test 2: Query API returning RegExp
+  console.log('Test 2: Query API returning RegExp');
+  const rx1 = query('ak');
+  assert.ok(rx1 instanceof RegExp, 'query() must return a native RegExp instance');
+  console.log('Query "ak" -> RegExp:', rx1.toString());
+
+  // Verify regex behavior on Japanese and Romaji strings
+  assert.ok(rx1.test('赤'), 'RegExp should match "赤"');
+  assert.ok(rx1.test('ak'), 'RegExp should match "ak"');
+
+  const rx2 = query('n');
+  assert.ok(rx2 instanceof RegExp, 'query("n") must return a native RegExp instance');
+  console.log('Query "n" -> RegExp:', rx2.toString());
+  assert.ok(rx2.test('なにぬねの'), 'RegExp should match "なにぬねの"');
+
+  // Test 3: Check exported runtime methods on module
+  console.log('Test 3: Verify Exported Runtime Utilities and C APIs');
+  const mod = getModule();
+  assert.ok(mod, 'Module instance should be defined');
+  assert.ok(typeof mod.FS === 'object', 'FS should be exported on module');
+  assert.ok(typeof mod.ccall === 'function', 'ccall should be exported on module');
+  assert.ok(typeof mod.cwrap === 'function', 'cwrap should be exported on module');
+  assert.ok(typeof mod.UTF8ToString === 'function', 'UTF8ToString should be exported on module');
+  assert.ok(typeof mod.allocate === 'function', 'allocate should be exported on module');
+  assert.ok(mod.ALLOC_NORMAL !== undefined, 'ALLOC_NORMAL should be exported on module');
+
+  assert.ok(typeof mod._migemo_open === 'function', '_migemo_open C API should be exported');
+  assert.ok(typeof mod._migemo_close === 'function', '_migemo_close C API should be exported');
+  assert.ok(typeof mod._migemo_query === 'function', '_migemo_query C API should be exported');
+  assert.ok(typeof mod._migemo_release === 'function', '_migemo_release C API should be exported');
+  assert.ok(typeof mod._migemo_load === 'function', '_migemo_load C API should be exported');
+
+  // Test 4: Re-initialization (Singleton Lifecycle & dictPath input)
+  console.log('Test 4: Re-initialization & Virtual FS Path');
+  // Write files to virtual FS directly
+  const virtualPath = '/virtual/opfs/migemo-dict';
+  mod.FS.mkdirTree('/virtual/opfs');
+  mod.FS.writeFile(virtualPath, dictBuffer);
+  mod.FS.writeFile('/virtual/opfs/roma2hira.dat', roma2hiraBuf);
+
+  const instance2 = await init({ dictPath: virtualPath });
+  assert.ok(instance2 > 0, 'New instance pointer should be valid');
+  assert.strictEqual(getInstance(), instance2, 'getInstance() should equal instance2');
+
+  const rx3 = query('ak');
+  assert.ok(rx3.test('明'), 'Query using re-initialized dictPath should match "明"');
+
+  // Test 5: Close API
+  console.log('Test 5: Close API');
+  close();
+  assert.strictEqual(getInstance(), 0, 'getInstance() should be 0 after close()');
+  assert.strictEqual(isEnable(), false, 'isEnable() should be false after close()');
+  assert.throws(() => query('ak'), /Migemo is not initialized/, 'query() should throw if not initialized');
+
+  console.log('All WASM Migemo tests passed successfully!');
+}
+
+runTests().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds WebAssembly (WASM) build configuration using Emscripten along with a high-level JavaScript wrapper to allow running C-Migemo in Web environments.

## Key Changes
- Added Emscripten build setup under `wasm/`.
- Included a high-level JavaScript API wrapper for easier integration.
- Updated artifact naming to use the version defined in `migemo.h`.