### PR TITLE
fix(rxgen): escape `+` character in regular expression generator

### DIFF
--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -163,6 +163,7 @@ rxgen_int2char_fallback(unsigned int in, unsigned char *out)
         case '\\':
         case '.':
         case '*':
+        case '+':
         case '^':
         case '$':
         case '/':


### PR DESCRIPTION
### Summary
Adds `+` to the character escape list in `rxgen_int2char_fallback` (`src/rxgen.c`). 

This prevents unescaped `+` quantifiers from being output in generated regular expressions when dictionary candidates contain `+` (e.g., "C++"), fixing `SyntaxError: Invalid regular expression: Nothing to repeat` errors in environments like JavaScript/WASM.

### Related Issue
Fixes #92