### PR TITLE
refactor(rxgen,charset): sanitize int2char contract and streamline escaping pipeline

### DIFF
--- a/include/migemo.h.in
+++ b/include/migemo.h.in
@@ -92,6 +92,8 @@ void MIGEMO_CALLTYPE migemo_setproc_char2int(
         migemo *mo, MIGEMO_PROC_CHAR2INT proc);
 void MIGEMO_CALLTYPE migemo_setproc_int2char(
         migemo *mo, MIGEMO_PROC_INT2CHAR proc);
+int MIGEMO_CALLTYPE migemo_set_escape_chars(
+        migemo *mo, const unsigned char *chars);
 
 int MIGEMO_CALLTYPE migemo_load(migemo *mo, int dict_id, const char *dict_file);
 int MIGEMO_CALLTYPE migemo_is_enable(migemo *mo);

--- a/include/migemo.h.in
+++ b/include/migemo.h.in
@@ -88,12 +88,12 @@ void MIGEMO_CALLTYPE migemo_release(migemo *mo, unsigned char *used_pattern);
 int MIGEMO_CALLTYPE migemo_set_operator(
         migemo *mo, int index, const unsigned char *op);
 const unsigned char *MIGEMO_CALLTYPE migemo_get_operator(migemo *mo, int index);
+void MIGEMO_CALLTYPE migemo_set_escape_chars(
+        migemo *mo, const unsigned char *chars);
 void MIGEMO_CALLTYPE migemo_setproc_char2int(
         migemo *mo, MIGEMO_PROC_CHAR2INT proc);
 void MIGEMO_CALLTYPE migemo_setproc_int2char(
         migemo *mo, MIGEMO_PROC_INT2CHAR proc);
-int MIGEMO_CALLTYPE migemo_set_escape_chars(
-        migemo *mo, const unsigned char *chars);
 
 int MIGEMO_CALLTYPE migemo_load(migemo *mo, int dict_id, const char *dict_file);
 int MIGEMO_CALLTYPE migemo_is_enable(migemo *mo);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,26 +14,35 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/migemo.rc"
   @ONLY)
 
+#------------------------------------------------------------------------------
+
+add_library(
+  migemo_objects
+  charset.c
+  filename.c
+  migemo.c
+  mtree.c
+  romaji.c
+  rxgen.c
+  trie.c
+  strbuf.c
+  wordlist.c)
+
+target_include_directories(
+  migemo_objects
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+
+set_target_properties(migemo_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+#------------------------------------------------------------------------------
+
 add_library(
   migemo
   SHARED
-    migemo.def
-    "${CMAKE_CURRENT_BINARY_DIR}/migemo.rc"
-    charset.c
-    filename.c
-    migemo.c
-    mtree.c
-    romaji.c
-    rxgen.c
-    trie.c
-    strbuf.c
-    wordlist.c)
-
-set_target_properties(
-  migemo
-  PROPERTIES
-    OUTPUT_NAME "migemo" VERSION ${PROJECT_VERSION} SOVERSION
-    ${PROJECT_VERSION_MAJOR})
+    migemo.def "${CMAKE_CURRENT_BINARY_DIR}/migemo.rc"
+    $<TARGET_OBJECTS:migemo_objects>)
 
 target_include_directories(
   migemo
@@ -41,6 +50,24 @@ target_include_directories(
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(
+  migemo
+  PROPERTIES
+    OUTPUT_NAME "migemo" VERSION ${PROJECT_VERSION} SOVERSION
+    ${PROJECT_VERSION_MAJOR})
+
+#------------------------------------------------------------------------------
+
+add_library(migemo_static STATIC $<TARGET_OBJECTS:migemo_objects>)
+
+target_include_directories(
+  migemo_static
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+
+#------------------------------------------------------------------------------
 
 add_executable(cmigemo main.c)
 

--- a/src/charset.c
+++ b/src/charset.c
@@ -58,8 +58,9 @@ charset_cp932_int2char(unsigned int in, unsigned char *out)
         }
         return 2;
     }
-    else
-        return 0;
+    if (out)
+        out[0] = (unsigned char)(in & 0xFF);
+    return 1;
 }
 
 #define IS_EUC_RANGE(c) (0xa1 <= (c) && (c) <= 0xfe)
@@ -94,8 +95,9 @@ charset_eucjp_int2char(unsigned int in, unsigned char *out)
         }
         return 2;
     }
-    else
-        return 0;
+    if (out)
+        out[0] = (unsigned char)(in & 0xFF);
+    return 1;
 }
 
 int
@@ -153,7 +155,11 @@ int
 charset_utf8_int2char(unsigned int in, unsigned char *out)
 {
     if (in < 0x80)
-        return 0;
+    {
+        if (out)
+            out[0] = (unsigned char)(in & 0xFF);
+        return 1;
+    }
     if (in < 0x800)
     {
         if (out)

--- a/src/charset.h
+++ b/src/charset.h
@@ -44,7 +44,7 @@ static inline unsigned int
 charset_decode(CHARSET_PROC_CHAR2INT proc, const unsigned char **pptr)
 {
     unsigned int code = 0;
-    int len = proc ? proc(*pptr, &code) : 0;
+    int len = proc(*pptr, &code);
     if (len == 0)
         len = charset_none_char2int(*pptr, &code);
     if (code)

--- a/src/charset.h
+++ b/src/charset.h
@@ -44,7 +44,7 @@ static inline unsigned int
 charset_decode(CHARSET_PROC_CHAR2INT proc, const unsigned char **pptr)
 {
     unsigned int code = 0;
-    int len = proc(*pptr, &code);
+    int len = proc ? proc(*pptr, &code) : 0;
     if (len == 0)
         len = charset_none_char2int(*pptr, &code);
     if (code)

--- a/src/charset.h
+++ b/src/charset.h
@@ -13,6 +13,9 @@ enum {
     CHARSET_UTF8 = 3,
 };
 
+// The maximum number of bytes into which a single code point can be expanded.
+#define CHARSET_MAX_BYTES 6
+
 typedef int (*charset_proc_char2int)(const unsigned char *, unsigned int *);
 typedef int (*charset_proc_int2char)(unsigned int, unsigned char *);
 #define CHARSET_PROC_CHAR2INT charset_proc_char2int

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -436,6 +436,18 @@ migemo_get_operator(migemo *mo, int index)
     return mo ? rxgen_get_operator(mo->rx, index) : NULL;
 }
 
+/// Set custom characters to escape in generated regular expressions.
+///
+/// @param mo Migemo object.
+/// @param chars String of characters to escape (ASCII 32-126). If NULL, default
+/// set ("\\.*+^$/") is used. If "", no characters are escaped.
+void MIGEMO_CALLTYPE
+migemo_set_escape_chars(migemo *mo, const unsigned char *chars)
+{
+    if (mo)
+        rxgen_set_escape_chars(mo->rx, chars);
+}
+
 /// Set a custom character conversion procedure (char -> int) for the Migemo
 /// object.
 ///
@@ -458,20 +470,6 @@ migemo_setproc_int2char(migemo *mo, MIGEMO_PROC_INT2CHAR proc)
 {
     if (mo)
         rxgen_setproc_int2char(mo->rx, (CHARSET_PROC_INT2CHAR)proc);
-}
-
-/// Set custom characters to escape in generated regular expressions.
-///
-/// @param mo Migemo object.
-/// @param chars String of characters to escape (ASCII 32-126). If NULL, default set is used. If "", no characters are escaped.
-/// @return 0 on success, non-zero on error (e.g. NULL mo).
-int MIGEMO_CALLTYPE
-migemo_set_escape_chars(migemo *mo, const unsigned char *chars)
-{
-    if (!mo)
-        return 1;
-    rxgen_set_escape_chars(mo->rx, chars);
-    return 0;
 }
 
 /// Check whether the main dictionary is loaded and ready for queries.

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -460,6 +460,20 @@ migemo_setproc_int2char(migemo *mo, MIGEMO_PROC_INT2CHAR proc)
         rxgen_setproc_int2char(mo->rx, (CHARSET_PROC_INT2CHAR)proc);
 }
 
+/// Set custom characters to escape in generated regular expressions.
+///
+/// @param mo Migemo object.
+/// @param chars String of characters to escape (ASCII 32-126). If NULL, default set is used. If "", no characters are escaped.
+/// @return 0 on success, non-zero on error (e.g. NULL mo).
+int MIGEMO_CALLTYPE
+migemo_set_escape_chars(migemo *mo, const unsigned char *chars)
+{
+    if (!mo)
+        return 1;
+    rxgen_set_escape_chars(mo->rx, chars);
+    return 0;
+}
+
 /// Check whether the main dictionary is loaded and ready for queries.
 ///
 /// @param mo Migemo object.

--- a/src/migemo.def
+++ b/src/migemo.def
@@ -9,9 +9,9 @@ EXPORTS
 	migemo_release
 	migemo_set_operator
 	migemo_get_operator
+	migemo_set_escape_chars
 	migemo_setproc_char2int
 	migemo_setproc_int2char
-	migemo_set_escape_chars
 
 	migemo_load
 	migemo_is_enable

--- a/src/migemo.def
+++ b/src/migemo.def
@@ -11,6 +11,7 @@ EXPORTS
 	migemo_get_operator
 	migemo_setproc_char2int
 	migemo_setproc_int2char
+	migemo_set_escape_chars
 
 	migemo_load
 	migemo_is_enable

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -180,7 +180,10 @@ romanode_balance(romanode *root)
 romaji *
 romaji_open()
 {
-    return (romaji *)calloc(1, sizeof(romaji));
+    romaji *rj = (romaji *)calloc(1, sizeof(romaji));
+    if (rj)
+        rj->char2int = charset_none_char2int;
+    return rj;
 }
 
 void
@@ -501,7 +504,7 @@ romaji_find_siblings(romaji *rj, romanode *node, unsigned int code)
 static inline size_t
 romaji_decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
 {
-    int len = proc ? proc(s, NULL) : 0;
+    int len = proc(s, NULL);
     return len > 0 ? (size_t)len : 1;
 }
 

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -181,8 +181,9 @@ romaji *
 romaji_open()
 {
     romaji *rj = (romaji *)calloc(1, sizeof(romaji));
-    if (rj)
-        rj->char2int = charset_none_char2int;
+    if (!rj)
+        return NULL;
+    rj->char2int = charset_none_char2int;
     return rj;
 }
 

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -501,7 +501,7 @@ romaji_find_siblings(romaji *rj, romanode *node, unsigned int code)
 static inline size_t
 romaji_decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
 {
-    int len = proc(s, NULL);
+    int len = proc ? proc(s, NULL) : 0;
     return len > 0 ? (size_t)len : 1;
 }
 

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -66,7 +66,7 @@ struct rxgen
     CHARSET_PROC_CHAR2INT char2int;
     CHARSET_PROC_INT2CHAR int2char;
 
-    uint32_t escapes_bitmap[3];
+    uint32_t escapes_bitmap[3]; // 3 = (126 - 32 + 1 + 31) / 32
 
     unsigned char op_or[RXGEN_OP_MAXLEN];
     unsigned char op_nest_in[RXGEN_OP_MAXLEN];
@@ -166,7 +166,7 @@ static int
 rxgen_int2char_fallback(rxgen *rx, unsigned int in, unsigned char *out)
 {
     int len = 0;
-    // Assume that out has at least 16 bytes
+    // Assume that "out" has at least 16 bytes
     if (in >= 32 && in <= 126)
     {
         unsigned int idx = in - 32;

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -65,6 +65,8 @@ struct rxgen
     CHARSET_PROC_CHAR2INT char2int;
     CHARSET_PROC_INT2CHAR int2char;
 
+    uint32_t bitmap[3];
+
     unsigned char op_or[RXGEN_OP_MAXLEN];
     unsigned char op_nest_in[RXGEN_OP_MAXLEN];
     unsigned char op_nest_out[RXGEN_OP_MAXLEN];
@@ -154,28 +156,23 @@ rxgen_char2int_fallback(const unsigned char *in, unsigned int *out)
 }
 
 static int
-rxgen_int2char_fallback(unsigned int in, unsigned char *out)
+rxgen_int2char_fallback(rxgen *rx, unsigned int in, unsigned char *out)
 {
     int len = 0;
     // Assume that out has at least 16 bytes
-    switch (in)
+    if (rx && in >= 32 && in <= 126)
     {
-        case '\\':
-        case '.':
-        case '*':
-        case '+':
-        case '^':
-        case '$':
-        case '/':
+        unsigned int idx = in - 32;
+        if (rx->bitmap[idx / 32] & (1U << (idx % 32)))
+        {
             if (out)
                 out[len] = '\\';
             ++len;
-        default:
-            if (out)
-                out[len] = (unsigned char)(in & 0xFF);
-            ++len;
-            break;
+        }
     }
+    if (out)
+        out[len] = (unsigned char)(in & 0xFF);
+    ++len;
     return len;
 }
 
@@ -190,7 +187,29 @@ void
 rxgen_setproc_int2char(rxgen *rx, CHARSET_PROC_INT2CHAR proc)
 {
     if (rx)
-        rx->int2char = proc ? proc : rxgen_int2char_fallback;
+        rx->int2char = proc;
+}
+
+void
+rxgen_set_escape_chars(rxgen *rx, const unsigned char *chars)
+{
+    if (!rx)
+        return;
+
+    memset(rx->bitmap, 0, sizeof(rx->bitmap));
+
+    if (chars == NULL)
+        chars = (const unsigned char *)"\\.*+^$/";
+
+    for (const unsigned char *p = chars; *p; ++p)
+    {
+        unsigned char c = *p;
+        if (c >= 32 && c <= 126)
+        {
+            unsigned int idx = c - 32;
+            rx->bitmap[idx / 32] |= (1U << (idx % 32));
+        }
+    }
 }
 
 static inline int
@@ -203,8 +222,8 @@ rxgen_call_char2int(rxgen *rx, const unsigned char *pch, unsigned int *code)
 static int
 rxgen_call_int2char(rxgen *rx, unsigned int code, unsigned char *buf)
 {
-    int len = rx->int2char(code, buf);
-    return len ? len : rxgen_int2char_fallback(code, buf);
+    int len = rx->int2char ? rx->int2char(code, buf) : 0;
+    return len ? len : rxgen_int2char_fallback(rx, code, buf);
 }
 
 rxgen *
@@ -215,6 +234,7 @@ rxgen_open()
     {
         rxgen_setproc_char2int(rx, NULL);
         rxgen_setproc_int2char(rx, NULL);
+        rxgen_set_escape_chars(rx, NULL);
         strcpy(rx->op_or, RXGEN_OP_OR);
         strcpy(rx->op_nest_in, RXGEN_OP_NEST_IN);
         strcpy(rx->op_nest_out, RXGEN_OP_NEST_OUT);

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -148,53 +148,18 @@ rnode_dig(rnode_arena *arena, rnode **pp, unsigned int code)
 
 // rxgen interfaces
 
-static int
-rxgen_char2int_fallback(const unsigned char *in, unsigned int *out)
-{
-    if (out)
-        *out = *in;
-    return 1;
-}
-
-static int
-rxgen_int2char_none(unsigned int in, unsigned char *out)
-{
-    return 0;
-}
-
-static int
-rxgen_int2char_fallback(rxgen *rx, unsigned int in, unsigned char *out)
-{
-    int len = 0;
-    // Assume that "out" has at least 16 bytes
-    if (in >= 32 && in <= 126)
-    {
-        unsigned int idx = in - 32;
-        if (rx->escapes_bitmap[idx / 32] & (1U << (idx % 32)))
-        {
-            if (out)
-                out[len] = '\\';
-            ++len;
-        }
-    }
-    if (out)
-        out[len] = (unsigned char)(in & 0xFF);
-    ++len;
-    return len;
-}
-
 void
 rxgen_setproc_char2int(rxgen *rx, CHARSET_PROC_CHAR2INT proc)
 {
     if (rx)
-        rx->char2int = proc ? proc : rxgen_char2int_fallback;
+        rx->char2int = proc ? proc : charset_none_char2int;
 }
 
 void
 rxgen_setproc_int2char(rxgen *rx, CHARSET_PROC_INT2CHAR proc)
 {
     if (rx)
-        rx->int2char = proc ? proc : rxgen_int2char_none;
+        rx->int2char = proc ? proc : charset_none_int2char;
 }
 
 void
@@ -217,20 +182,6 @@ rxgen_set_escape_chars(rxgen *rx, const unsigned char *chars)
             rx->escapes_bitmap[idx / 32] |= (1U << (idx % 32));
         }
     }
-}
-
-static inline int
-rxgen_call_char2int(rxgen *rx, const unsigned char *pch, unsigned int *code)
-{
-    int len = rx->char2int(pch, code);
-    return len ? len : rxgen_char2int_fallback(pch, code);
-}
-
-static int
-rxgen_call_int2char(rxgen *rx, unsigned int code, unsigned char *buf)
-{
-    int len = rx->int2char(code, buf);
-    return len ? len : rxgen_int2char_fallback(rx, code, buf);
 }
 
 rxgen *
@@ -273,7 +224,7 @@ rxgen_add(rxgen *rx, const unsigned char *word)
     while (1)
     {
         unsigned int code;
-        int len = rxgen_call_char2int(rx, word, &code);
+        int len = rx->char2int(word, &code);
 
         // Terminate if the input pattern is exhausted
         if (code == 0)
@@ -330,14 +281,29 @@ rxgen_rnode_count(rnode *node, int *childrenCount, int *brotherCount)
     }
 }
 
-static void rxgen_generate_stub(rxgen *rx, strbuf *buf, rnode *node);
+static inline void rxgen_append_ch(rxgen *rx, strbuf *buf, unsigned int code)
+{
+    unsigned char bytes[CHARSET_MAX_BYTES];
+    int len = rx->int2char(code, bytes);
+    strbuf_append_mem(buf, bytes, len);
+}
+
+static inline bool
+rxgen_is_escape(rxgen *rx, unsigned int code)
+{
+    if (code < 32 || code > 126)
+        return false;
+    unsigned int idx = code - 32;
+    return rx->escapes_bitmap[idx / 32] & (1U << (idx % 32));
+}
 
 static void
 rxgen_write_node_code(rxgen *rx, strbuf *buf, rnode *node)
 {
-    unsigned char bytes[6];
-    int len = rxgen_call_int2char(rx, node->code, bytes);
-    strbuf_append_mem(buf, bytes, len);
+    unsigned int code = node->code;
+    if (rxgen_is_escape(rx, code))
+        rxgen_append_ch(rx, buf, '\\');
+    rxgen_append_ch(rx, buf, code);
 }
 
 static void
@@ -350,6 +316,8 @@ rxgen_write_node_no_children(rxgen *rx, strbuf *buf, rnode *node)
     if (node->high)
         rxgen_write_node_no_children(rx, buf, node->high);
 }
+
+static void rxgen_generate_stub(rxgen *rx, strbuf *buf, rnode *node);
 
 static void
 rxgen_write_node_has_children(rxgen *rx, strbuf *buf, rnode *node, bool *needOr)

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -7,6 +7,7 @@
 #include "common.h"
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -65,7 +66,7 @@ struct rxgen
     CHARSET_PROC_CHAR2INT char2int;
     CHARSET_PROC_INT2CHAR int2char;
 
-    uint32_t bitmap[3];
+    uint32_t escapes_bitmap[3];
 
     unsigned char op_or[RXGEN_OP_MAXLEN];
     unsigned char op_nest_in[RXGEN_OP_MAXLEN];
@@ -156,14 +157,20 @@ rxgen_char2int_fallback(const unsigned char *in, unsigned int *out)
 }
 
 static int
+rxgen_int2char_none(unsigned int in, unsigned char *out)
+{
+    return 0;
+}
+
+static int
 rxgen_int2char_fallback(rxgen *rx, unsigned int in, unsigned char *out)
 {
     int len = 0;
     // Assume that out has at least 16 bytes
-    if (rx && in >= 32 && in <= 126)
+    if (in >= 32 && in <= 126)
     {
         unsigned int idx = in - 32;
-        if (rx->bitmap[idx / 32] & (1U << (idx % 32)))
+        if (rx->escapes_bitmap[idx / 32] & (1U << (idx % 32)))
         {
             if (out)
                 out[len] = '\\';
@@ -187,7 +194,7 @@ void
 rxgen_setproc_int2char(rxgen *rx, CHARSET_PROC_INT2CHAR proc)
 {
     if (rx)
-        rx->int2char = proc;
+        rx->int2char = proc ? proc : rxgen_int2char_none;
 }
 
 void
@@ -196,7 +203,7 @@ rxgen_set_escape_chars(rxgen *rx, const unsigned char *chars)
     if (!rx)
         return;
 
-    memset(rx->bitmap, 0, sizeof(rx->bitmap));
+    memset(rx->escapes_bitmap, 0, sizeof(rx->escapes_bitmap));
 
     if (chars == NULL)
         chars = (const unsigned char *)"\\.*+^$/";
@@ -207,7 +214,7 @@ rxgen_set_escape_chars(rxgen *rx, const unsigned char *chars)
         if (c >= 32 && c <= 126)
         {
             unsigned int idx = c - 32;
-            rx->bitmap[idx / 32] |= (1U << (idx % 32));
+            rx->escapes_bitmap[idx / 32] |= (1U << (idx % 32));
         }
     }
 }
@@ -222,7 +229,7 @@ rxgen_call_char2int(rxgen *rx, const unsigned char *pch, unsigned int *code)
 static int
 rxgen_call_int2char(rxgen *rx, unsigned int code, unsigned char *buf)
 {
-    int len = rx->int2char ? rx->int2char(code, buf) : 0;
+    int len = rx->int2char(code, buf);
     return len ? len : rxgen_int2char_fallback(rx, code, buf);
 }
 

--- a/src/rxgen.h
+++ b/src/rxgen.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include "charset.h"
 
 typedef struct rxgen rxgen;

--- a/src/rxgen.h
+++ b/src/rxgen.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "charset.h"
 
 typedef struct rxgen rxgen;
@@ -35,6 +37,7 @@ void rxgen_reset(rxgen *rx);
 // Configuration
 void rxgen_setproc_char2int(rxgen *rx, CHARSET_PROC_CHAR2INT proc);
 void rxgen_setproc_int2char(rxgen *rx, CHARSET_PROC_INT2CHAR proc);
+void rxgen_set_escape_chars(rxgen *rx, const unsigned char *chars);
 int rxgen_set_operator(rxgen *rx, int index, const unsigned char *op);
 const unsigned char *rxgen_get_operator(rxgen *rx, int index);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test1 main.c test1.c test2.c)
+add_executable(test1 main.c test1.c test_rxgen.c)
 
 target_link_libraries(test1 PRIVATE migemo_static)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test1 main.c test1.c)
+add_executable(test1 main.c test1.c test2.c)
 
 target_link_libraries(test1 PRIVATE migemo)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(test1 main.c test1.c test2.c)
 
-target_link_libraries(test1 PRIVATE migemo)
+target_link_libraries(test1 PRIVATE migemo_static)
 
 target_include_directories(test1 PRIVATE ${PROJECT_SOURCE_DIR}/src)
 

--- a/test/main.c
+++ b/test/main.c
@@ -13,5 +13,6 @@ main(int argc, char **argv)
         return r;
     if ((r = test2()) != 0)
         return r;
+    // FIXME: Future test cases (group) will be added here.
     return 0;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 int test1(void);
+int test2(void);
 
 int
 main(int argc, char **argv)
@@ -10,6 +11,7 @@ main(int argc, char **argv)
     int r;
     if ((r = test1()) != 0)
         return r;
-    // FIXME: Future test cases (group) will be added here.
+    if ((r = test2()) != 0)
+        return r;
     return 0;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 int test1(void);
-int test2(void);
+int test_rxgen(void);
 
 int
 main(int argc, char **argv)
@@ -11,7 +11,7 @@ main(int argc, char **argv)
     int r;
     if ((r = test1()) != 0)
         return r;
-    if ((r = test2()) != 0)
+    if ((r = test_rxgen()) != 0)
         return r;
     // FIXME: Future test cases (group) will be added here.
     return 0;

--- a/test/test2.c
+++ b/test/test2.c
@@ -69,11 +69,6 @@ test2(void)
     rxgen_close(rx);
 
     // Test migemo_set_escape_chars API
-    if (migemo_set_escape_chars(NULL, (const unsigned char *)"+") == 0)
-    {
-        printf("Failed: migemo_set_escape_chars(NULL, ...) should return non-zero\n");
-        return 1;
-    }
 
     migemo *mo = migemo_open(NULL);
     if (!mo)
@@ -81,13 +76,7 @@ test2(void)
         printf("Failed: migemo_open(NULL) returned NULL\n");
         return 1;
     }
-
-    if (migemo_set_escape_chars(mo, (const unsigned char *)"+?") != 0)
-    {
-        printf("Failed: migemo_set_escape_chars(mo, \"+?\") returned non-zero\n");
-        migemo_close(mo);
-        return 1;
-    }
+    migemo_set_escape_chars(mo, (const unsigned char *)"+?");
 
     unsigned char *qres = migemo_query(mo, (const unsigned char *)"a+b?c.d");
     if (!qres)

--- a/test/test2.c
+++ b/test/test2.c
@@ -1,0 +1,111 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+
+#include <stdio.h>
+#include <string.h>
+
+#include "migemo.h"
+#include "rxgen.h"
+
+int
+test2(void)
+{
+    rxgen *rx = rxgen_open();
+    if (!rx)
+    {
+        printf("Failed: rxgen_open() returned NULL\n");
+        return 1;
+    }
+
+    // Test rxgen_set_escape_chars with NULL (default set: \.*+^$/)
+    rxgen_set_escape_chars(rx, NULL);
+    rxgen_add(rx, (const unsigned char *)"a+b.c*d^e$f/g\\h?i");
+    unsigned char *pat = rxgen_generate(rx);
+    if (!pat)
+    {
+        printf("Failed: rxgen_generate() returned NULL\n");
+        rxgen_close(rx);
+        return 1;
+    }
+    const char *expected_default = "a\\+b\\.c\\*d\\^e\\$f\\/g\\\\h?i";
+    if (strcmp((const char *)pat, expected_default) != 0)
+    {
+        printf("Failed default rxgen escape: got \"%s\", expected \"%s\"\n", pat, expected_default);
+        rxgen_release(rx, pat);
+        rxgen_close(rx);
+        return 1;
+    }
+    rxgen_release(rx, pat);
+
+    // Test rxgen_set_escape_chars with custom string including out-of-range chars
+    rxgen_reset(rx);
+    // Escape '?' and '+' (plus ASCII out-of-range chars 0x01, 0xFF)
+    rxgen_set_escape_chars(rx, (const unsigned char *)"\x01?+\xFF");
+    rxgen_add(rx, (const unsigned char *)"a+b.c?d");
+    pat = rxgen_generate(rx);
+    const char *expected_custom = "a\\+b.c\\?d";
+    if (strcmp((const char *)pat, expected_custom) != 0)
+    {
+        printf("Failed custom rxgen escape: got \"%s\", expected \"%s\"\n", pat, expected_custom);
+        rxgen_release(rx, pat);
+        rxgen_close(rx);
+        return 1;
+    }
+    rxgen_release(rx, pat);
+
+    // Test rxgen_set_escape_chars with empty string "" (no escaping)
+    rxgen_reset(rx);
+    rxgen_set_escape_chars(rx, (const unsigned char *)"");
+    rxgen_add(rx, (const unsigned char *)"a+b.c\\d");
+    pat = rxgen_generate(rx);
+    const char *expected_empty = "a+b.c\\d";
+    if (strcmp((const char *)pat, expected_empty) != 0)
+    {
+        printf("Failed empty rxgen escape: got \"%s\", expected \"%s\"\n", pat, expected_empty);
+        rxgen_release(rx, pat);
+        rxgen_close(rx);
+        return 1;
+    }
+    rxgen_release(rx, pat);
+    rxgen_close(rx);
+
+    // Test migemo_set_escape_chars API
+    if (migemo_set_escape_chars(NULL, (const unsigned char *)"+") == 0)
+    {
+        printf("Failed: migemo_set_escape_chars(NULL, ...) should return non-zero\n");
+        return 1;
+    }
+
+    migemo *mo = migemo_open(NULL);
+    if (!mo)
+    {
+        printf("Failed: migemo_open(NULL) returned NULL\n");
+        return 1;
+    }
+
+    if (migemo_set_escape_chars(mo, (const unsigned char *)"+?") != 0)
+    {
+        printf("Failed: migemo_set_escape_chars(mo, \"+?\") returned non-zero\n");
+        migemo_close(mo);
+        return 1;
+    }
+
+    unsigned char *qres = migemo_query(mo, (const unsigned char *)"a+b?c.d");
+    if (!qres)
+    {
+        printf("Failed: migemo_query returned NULL\n");
+        migemo_close(mo);
+        return 1;
+    }
+    const char *expected_migemo = "a\\+b\\?c.d";
+    if (strcmp((const char *)qres, expected_migemo) != 0)
+    {
+        printf("Failed migemo custom escape query: got \"%s\", expected \"%s\"\n", qres, expected_migemo);
+        migemo_release(mo, qres);
+        migemo_close(mo);
+        return 1;
+    }
+    migemo_release(mo, qres);
+    migemo_close(mo);
+
+    return 0;
+}

--- a/test/test_rxgen.c
+++ b/test/test_rxgen.c
@@ -7,7 +7,7 @@
 #include "rxgen.h"
 
 int
-test2(void)
+test_rxgen(void)
 {
     rxgen *rx = rxgen_open();
     if (!rx)

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_options(
   PRIVATE
     "--js-library"
     "${CMAKE_CURRENT_SOURCE_DIR}/library.js"
-    "-sEXPORTED_FUNCTIONS=['_migemo_open','_migemo_close','_migemo_query','_migemo_release','_migemo_load','_migemo_is_enable','_malloc','_free']"
+    "-sEXPORTED_FUNCTIONS=['_migemo_open','_migemo_close','_migemo_query','_migemo_release','_migemo_load','_migemo_is_enable','_migemo_set_escape_chars','_malloc','_free']"
     "-sEXPORTED_RUNTIME_METHODS=['FS','ccall','cwrap','UTF8ToString','allocate','ALLOC_NORMAL']"
     "-sMODULARIZE=1"
     "-sEXPORT_NAME='createMigemoModule'"

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -152,6 +152,10 @@ export async function init(options = {}) {
     throw new Error(`Failed to initialize Migemo with dictPath: ${dictPath}`);
   }
 
+  const migemoSetEscapeChars = moduleInstance.cwrap('migemo_set_escape_chars', 'number', ['number', 'string']);
+  const jsEscapeChars = '\\.*+?^${}()|[]/';
+  migemoSetEscapeChars(migemoInstance, jsEscapeChars);
+
   return migemoInstance;
 }
 
@@ -215,6 +219,19 @@ export function load(dictId, dictPath) {
 }
 
 /**
+ * Sets custom characters to escape in generated regular expressions.
+ * @param {string|null} chars String of characters to escape, or null to restore default.
+ * @returns {number} 0 on success, non-zero on error.
+ */
+export function setEscapeChars(chars) {
+  if (!migemoInstance || !moduleInstance) {
+    throw new Error("Migemo is not initialized. Call init() first.");
+  }
+  const migemoSetEscapeChars = moduleInstance.cwrap('migemo_set_escape_chars', 'number', ['number', 'string']);
+  return migemoSetEscapeChars(migemoInstance, chars);
+}
+
+/**
  * Returns the underlying Emscripten module instance.
  * @returns {Object|null}
  */
@@ -236,6 +253,7 @@ export default {
   close,
   isEnable,
   load,
+  setEscapeChars,
   getModule,
   getInstance
 };


### PR DESCRIPTION
## Summary

This PR introduces a customizable character escaping feature for generated regular expressions while completely sanitizing the character conversion and escaping pipeline across `rxgen` and `charset` modules.

It supersedes the temporary approach in #95 by resolving underlying technical debt and providing a clean, robust design.

## Key Changes

- **API & Core Interface**:
  - Added `migemo_set_escape_chars` to configure custom escape character sets via a 96-bit bitmap.
  - Standardized `migemo_set_escape_chars` return type to `void` for consistency with other setter APIs.
- **`charset` Module Normalization**:
  - Normalized `charset_*_int2char` procedures (CP932, EUC-JP, UTF-8) to return `1` for 1-byte ASCII characters instead of `0`.
  - Defined `CHARSET_MAX_BYTES` (6) in `charset.h` to establish clear buffer size guarantees across modules.
- **`rxgen` Architecture Cleanup**:
  - Eliminated implicit fallback functions (`rxgen_call_*`, `rxgen_int2char_fallback`, `rxgen_int2char_none`).
  - Streamlined `rxgen_write_node_code` into a direct pipeline: evaluate escape status via bitmap and emit characters explicitly through `int2char`.
- **Build & Infrastructure**:
  - Added `migemo_static` library target in CMake to facilitate internal static testing.

## Related Issues
Closes #92, Closes #94