### PR TITLE
feat(api): add migemo_version function to retrieve C/Migemo version

### DIFF
--- a/include/migemo.h.in
+++ b/include/migemo.h.in
@@ -48,6 +48,13 @@ extern "C" {
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// Information
+
+/// Get version string of C/Migemo library.
+/// @return Pointer to a static version string (e.g. "1.6.1").
+const char *MIGEMO_CALLTYPE migemo_version(void);
+
+//////////////////////////////////////////////////////////////////////////////
 // Life cycle management
 
 /// Create a Migemo object.

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -488,5 +488,5 @@ migemo_is_enable(migemo *mo)
 const char *MIGEMO_CALLTYPE
 migemo_version(void)
 {
-    return MIGEMO_VERSION;
+    return MIGEMO_VERSION MIGEMO_VERSION_PRERELEASE;
 }

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -481,3 +481,12 @@ migemo_is_enable(migemo *mo)
 {
     return mo ? mo->enable : 0;
 }
+
+/// Retrieve the version string of the C/Migemo library.
+///
+/// @return Static version string (e.g., "1.6.1").
+const char *MIGEMO_CALLTYPE
+migemo_version(void)
+{
+    return MIGEMO_VERSION;
+}

--- a/src/migemo.def
+++ b/src/migemo.def
@@ -15,3 +15,4 @@ EXPORTS
 
 	migemo_load
 	migemo_is_enable
+	migemo_version

--- a/test/test1.c
+++ b/test/test1.c
@@ -47,6 +47,14 @@ test1(void)
     int r;
     migemo *p;
 
+    const char *ver = migemo_version();
+    if (ver == NULL || strcmp(ver, MIGEMO_VERSION) != 0)
+    {
+        printf("Failed: migemo_version() returned \"%s\" (expected \"%s\")\n",
+                ver ? ver : "(null)", MIGEMO_VERSION);
+        return 1;
+    }
+
     p = migemo_open(TEST_DICTDIR_MIGEMO "/migemo-dict");
     if (p == NULL)
     {

--- a/test/test1.c
+++ b/test/test1.c
@@ -48,10 +48,10 @@ test1(void)
     migemo *p;
 
     const char *ver = migemo_version();
-    if (ver == NULL || strcmp(ver, MIGEMO_VERSION) != 0)
+    if (ver == NULL || strcmp(ver, MIGEMO_VERSION MIGEMO_VERSION_PRERELEASE) != 0)
     {
         printf("Failed: migemo_version() returned \"%s\" (expected \"%s\")\n",
-                ver ? ver : "(null)", MIGEMO_VERSION);
+                ver ? ver : "(null)", MIGEMO_VERSION MIGEMO_VERSION_PRERELEASE);
         return 1;
     }
 

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_options(
   PRIVATE
     "--js-library"
     "${CMAKE_CURRENT_SOURCE_DIR}/library.js"
-    "-sEXPORTED_FUNCTIONS=['_migemo_open','_migemo_close','_migemo_query','_migemo_release','_migemo_load','_migemo_is_enable','_migemo_set_escape_chars','_malloc','_free']"
+    "-sEXPORTED_FUNCTIONS=['_migemo_open','_migemo_close','_migemo_query','_migemo_release','_migemo_load','_migemo_is_enable','_migemo_set_escape_chars','_migemo_version','_malloc','_free']"
     "-sEXPORTED_RUNTIME_METHODS=['FS','ccall','cwrap','UTF8ToString','allocate','ALLOC_NORMAL']"
     "-sMODULARIZE=1"
     "-sEXPORT_NAME='createMigemoModule'"

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -232,6 +232,18 @@ export function setEscapeChars(chars) {
 }
 
 /**
+ * Returns the version string of the C/Migemo library.
+ * @returns {string} Version string (e.g., "1.6.1")
+ */
+export function version() {
+  if (!moduleInstance) {
+    throw new Error("Migemo is not initialized. Call init() first.");
+  }
+  const migemoVersion = moduleInstance.cwrap('migemo_version', 'string', []);
+  return migemoVersion();
+}
+
+/**
  * Returns the underlying Emscripten module instance.
  * @returns {Object|null}
  */
@@ -254,6 +266,7 @@ export default {
   isEnable,
   load,
   setEscapeChars,
+  version,
   getModule,
   getInstance
 };

--- a/wasm/test/test.js
+++ b/wasm/test/test.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
-import { init, query, close, isEnable, load, getModule, getInstance } from '../index.js';
+import { init, query, close, isEnable, load, version, getModule, getInstance } from '../index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -72,6 +72,11 @@ async function runTests() {
   assert.ok(typeof mod._migemo_query === 'function', '_migemo_query C API should be exported');
   assert.ok(typeof mod._migemo_release === 'function', '_migemo_release C API should be exported');
   assert.ok(typeof mod._migemo_load === 'function', '_migemo_load C API should be exported');
+  assert.ok(typeof mod._migemo_version === 'function', '_migemo_version C API should be exported');
+
+  const ver = version();
+  assert.ok(typeof ver === 'string' && ver.length > 0, 'version() should return a non-empty string');
+  console.log('Version:', ver);
 
   // Test 4: Re-initialization (Singleton Lifecycle & dictPath input)
   console.log('Test 4: Re-initialization & Virtual FS Path');


### PR DESCRIPTION
Adds the `migemo_version()` function to the C API, exports `_migemo_version` in WASM build configuration, exposes `version()` in the JavaScript wrapper, and adds tests verifying functionality.

---
*PR created automatically by Jules for task [105739726902973222](https://jules.google.com/task/105739726902973222) started by @koron*