### PR TITLE
refactor(rxgen): optimize node traversal and cleanup build settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,7 @@ if(COMPILER_SUPPORTS_WNO_POINTER_SIGN)
   add_compile_options(-Wno-pointer-sign)
 endif()
 
-# Optimization flags
-if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options($<$<CONFIG:Release>:-O2>)
-endif()
-
+# Disable MSVC warnings
 if(MSVC)
   add_compile_options(/utf-8 /W3 /wd4710 /wd4711 /wd5045)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # C/Migemo Makefile
 
-.PHONY: build test profile tags format package clean distclean
+.PHONY: build test profile tags format format-cmake package clean distclean
 
 build:
 	cmake -B build
@@ -21,6 +21,9 @@ profile:
 
 format:
 	find src test include -type f \( -name "*.c" -o -name "*.h" \) | xargs clang-format -i
+
+format-cmake:
+	cmakefmt --in-place .
 
 package:
 	cmake -B build -DCMAKE_BUILD_TYPE=Release

--- a/src/charset.c
+++ b/src/charset.c
@@ -104,11 +104,7 @@ int
 charset_utf8_char2int(const unsigned char *in, unsigned int *out)
 {
     if (!(in[0] & 0x80))
-    {
-        if (out)
-            *out = in[0];
-        return 1;
-    }
+        return charset_none_char2int(in, out);
 
     // Use LUT to determine number of continuation bytes in UTF-8.
     // clang-format off
@@ -135,14 +131,16 @@ charset_utf8_char2int(const unsigned char *in, unsigned int *out)
     // clang-format on
     int len = UTF8_LUT[in[0] - 128];
     if (!len)
-        return 0;
+        // Output an invalid byte as-is.
+        return charset_none_char2int(in, out);
 
     unsigned int code = in[0] & (0xff >> len);
     for (int i = 1; i < len; ++i)
     {
         // check invalid byte.
         if ((in[i] & 0xc0) != 0x80)
-            return 0;
+            // Output an invalid byte as-is.
+            return charset_none_char2int(in, out);
         code <<= 6;
         code += in[i] & 0x3f;
     }

--- a/src/charset.h
+++ b/src/charset.h
@@ -47,10 +47,6 @@ static inline unsigned int
 charset_decode(CHARSET_PROC_CHAR2INT proc, const unsigned char **pptr)
 {
     unsigned int code = 0;
-    int len = proc(*pptr, &code);
-    if (len == 0)
-        len = charset_none_char2int(*pptr, &code);
-    if (code)
-        *pptr += len;
+    *pptr += proc(*pptr, &code);
     return code;
 }

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -115,13 +115,8 @@ rnode_arena_free(rnode_arena *arena)
 static rnode *
 rnode_dig(rnode_arena *arena, rnode **pp, unsigned int code)
 {
-    while (1)
+    while (*pp)
     {
-        if (*pp == NULL)
-        {
-            *pp = rnode_arena_alloc(arena, code);
-            return *pp;
-        }
         int pivot = (*pp)->code;
         if (code > pivot)
             pp = &(*pp)->high;
@@ -130,6 +125,8 @@ rnode_dig(rnode_arena *arena, rnode **pp, unsigned int code)
         else
             return *pp;
     }
+    *pp = rnode_arena_alloc(arena, code);
+    return *pp;
 }
 
 // rxgen interfaces

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -210,37 +210,30 @@ rxgen_add(rxgen *rx, const unsigned char *word)
 
         // Terminate if the input pattern is exhausted
         if (code == 0)
-        {
-            if (pnode)
-                pnode->wordtail = true;
-            if (*ppnode)
-            {
-                // If a longer word is already registered than the one being
-                // registered, discard the longer one. E.g.:
-                //      赤ちゃん + 赤   -> 赤
-                //      国際便   + 国際 -> 国際
-                *ppnode = NULL;
-                // FIXME: mark *ppnode here for future use when collecting
-                // statistical information or reusing reclaimed nodes.
-            }
             break;
-        }
 
         pnode = rnode_dig(&rx->arena, ppnode, code);
         if (!pnode)
             return 0; // allocation error.
         if (pnode->wordtail)
-        {
             // If a shorter word is already registered than the one being
             // registered, discard the remaining characters. E.g.:
             //      赤   + 赤ちゃん -> 赤
             //      国際 + 国際便   -> 国際
             return 2; // not registered a word, but found short one.
-        }
 
         // Move the focus deeper by traversing child nodes
         ppnode = &pnode->child;
     }
+
+    if (pnode)
+        pnode->wordtail = true;
+    if (*ppnode)
+        // If a longer word is already registered than the one being
+        // registered, discard the longer one. E.g.:
+        //      赤ちゃん + 赤   -> 赤
+        //      国際便   + 国際 -> 国際
+        *ppnode = NULL;
     return 1; // registered a word, some nodes.
 }
 

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -232,17 +232,17 @@ rxgen_add(rxgen *rx, const unsigned char *word)
         pnode = rnode_dig(&rx->arena, ppnode, code);
         if (!pnode)
             return 0; // allocation error.
-        ppnode = &pnode->child;
-
-        if (pnode && pnode->wordtail)
+        if (pnode->wordtail)
         {
             // If a shorter word is already registered than the one being
             // registered, discard the remaining characters. E.g.:
-            //      赤ちゃん + 赤   -> 赤
-            //      国際便   + 国際 -> 国際
+            //      赤   + 赤ちゃん -> 赤
+            //      国際 + 国際便   -> 国際
             return 2; // not registered a word, but found short one.
         }
+
         // Move the focus deeper by traversing child nodes
+        ppnode = &pnode->child;
     }
     return 1; // registered a word, some nodes.
 }

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -115,34 +115,20 @@ rnode_arena_free(rnode_arena *arena)
 static rnode *
 rnode_dig(rnode_arena *arena, rnode **pp, unsigned int code)
 {
-    rnode *p = *pp;
-    if (p == NULL)
-    {
-        *pp = rnode_arena_alloc(arena, code);
-        return *pp;
-    }
     while (1)
     {
-        if (code == p->code)
-            return p;
-        if (code < p->code)
+        if (*pp == NULL)
         {
-            if (p->low == NULL)
-            {
-                p->low = rnode_arena_alloc(arena, code);
-                return p->low;
-            }
-            p = p->low;
+            *pp = rnode_arena_alloc(arena, code);
+            return *pp;
         }
+        int pivot = (*pp)->code;
+        if (code > pivot)
+            pp = &(*pp)->high;
+        else if (code < pivot)
+            pp = &(*pp)->low;
         else
-        {
-            if (p->high == NULL)
-            {
-                p->high = rnode_arena_alloc(arena, code);
-                return p->high;
-            }
-            p = p->high;
-        }
+            return *pp;
     }
 }
 

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -264,7 +264,8 @@ rxgen_rnode_count(rnode *node, int *childrenCount, int *brotherCount)
     }
 }
 
-static inline void rxgen_append_ch(rxgen *rx, strbuf *buf, unsigned int code)
+static inline void
+rxgen_append_ch(rxgen *rx, strbuf *buf, unsigned int code)
 {
     unsigned char bytes[CHARSET_MAX_BYTES];
     int len = rx->int2char(code, bytes);

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -112,7 +112,7 @@ rnode_arena_free(rnode_arena *arena)
     arena->curr = NULL;
 }
 
-static rnode *
+static inline rnode *
 rnode_dig(rnode_arena *arena, rnode **pp, unsigned int code)
 {
     while (*pp)

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -117,7 +117,7 @@ rnode_dig(rnode_arena *arena, rnode **pp, unsigned int code)
 {
     while (*pp)
     {
-        int pivot = (*pp)->code;
+        unsigned int pivot = (*pp)->code;
         if (code > pivot)
             pp = &(*pp)->high;
         else if (code < pivot)

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -206,8 +206,7 @@ rxgen_add(rxgen *rx, const unsigned char *word)
     rnode *pnode = NULL;
     while (1)
     {
-        unsigned int code;
-        int len = rx->char2int(word, &code);
+        unsigned int code = charset_decode(rx->char2int, &word);
 
         // Terminate if the input pattern is exhausted
         if (code == 0)
@@ -226,8 +225,6 @@ rxgen_add(rxgen *rx, const unsigned char *word)
             }
             break;
         }
-
-        word += len;
 
         pnode = rnode_dig(&rx->arena, ppnode, code);
         if (!pnode)

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -55,21 +55,15 @@ strbuf_extend(strbuf *sb, size_t req_len)
         return 0;
 
     size_t newlen = sb->cap * 2;
-    unsigned char *newbuf;
-
     while (req_len > newlen)
         newlen *= 2;
+
+    unsigned char *newbuf;
     if (!(newbuf = (unsigned char *)realloc(sb->buf, newlen)))
-    {
-        // fprintf(stderr, "strbuf_add(): failed to extend buffer\n");
         return 0;
-    }
-    else
-    {
-        sb->cap = newlen;
-        sb->buf = newbuf;
-        return req_len;
-    }
+    sb->cap = newlen;
+    sb->buf = newbuf;
+    return req_len;
 }
 
 size_t

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -8,12 +8,14 @@ add_executable(
   ${PROJECT_SOURCE_DIR}/src/trie.c
   ${PROJECT_SOURCE_DIR}/src/strbuf.c
   ${PROJECT_SOURCE_DIR}/src/wordlist.c)
+
 target_include_directories(
   romaji
   PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src/include)
+
 target_compile_definitions(
   romaji
-  PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8" _DEBUG)
+  PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8")
 
 if(MSVC)
   set_target_properties(
@@ -37,12 +39,14 @@ add_executable(
   ${PROJECT_SOURCE_DIR}/src/trie.c
   ${PROJECT_SOURCE_DIR}/src/strbuf.c
   ${PROJECT_SOURCE_DIR}/src/wordlist.c)
+
 target_include_directories(
   qspeed
   PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src/include)
+
 target_compile_definitions(
   qspeed
-  PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8" _DEBUG)
+  PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8")
 
 if(MSVC)
   set_target_properties(
@@ -57,8 +61,8 @@ endif()
 find_program(GPROF_EXECUTABLE gprof)
 
 if(GPROF_EXECUTABLE AND CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-  target_compile_options(qspeed PRIVATE -O0 -pg)
-  target_link_options(qspeed PRIVATE -O0 -pg)
+  target_compile_options(qspeed PRIVATE -pg -fno-omit-frame-pointer)
+  target_link_options(qspeed PRIVATE -pg -fno-omit-frame-pointer)
 
   if(BUILD_DICT)
     add_dependencies(qspeed dict_utf-8)

--- a/src/testdir/CMakeLists.txt
+++ b/src/testdir/CMakeLists.txt
@@ -17,14 +17,6 @@ target_compile_definitions(
   romaji
   PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8")
 
-if(MSVC)
-  set_target_properties(
-    romaji
-    PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDebug")
-elseif(MINGW)
-  target_link_libraries(romaji PRIVATE ucrtbased)
-endif()
-
 #------------------------------------------------------------------------------
 # qspeed: profiling tool
 add_executable(
@@ -47,14 +39,6 @@ target_include_directories(
 target_compile_definitions(
   qspeed
   PRIVATE DICTDIR="${PROJECT_BINARY_DIR}/dict/utf-8")
-
-if(MSVC)
-  set_target_properties(
-    qspeed
-    PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDebug")
-elseif(MINGW)
-  target_link_libraries(qspeed PRIVATE ucrtbased)
-endif()
 
 #------------------------------------------------------------------------------
 # Profiling target "profile": `cmake --build build --target profile`

--- a/src/trie.c
+++ b/src/trie.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 
+#include "common.h"
 #include "trie.h"
 
 void

--- a/test/test1.c
+++ b/test/test1.c
@@ -48,7 +48,8 @@ test1(void)
     migemo *p;
 
     const char *ver = migemo_version();
-    if (ver == NULL || strcmp(ver, MIGEMO_VERSION MIGEMO_VERSION_PRERELEASE) != 0)
+    if (ver == NULL
+            || strcmp(ver, MIGEMO_VERSION MIGEMO_VERSION_PRERELEASE) != 0)
     {
         printf("Failed: migemo_version() returned \"%s\" (expected \"%s\")\n",
                 ver ? ver : "(null)", MIGEMO_VERSION MIGEMO_VERSION_PRERELEASE);

--- a/test/test_rxgen.c
+++ b/test/test_rxgen.c
@@ -29,14 +29,16 @@ test_rxgen(void)
     const char *expected_default = "a\\+b\\.c\\*d\\^e\\$f\\/g\\\\h?i";
     if (strcmp((const char *)pat, expected_default) != 0)
     {
-        printf("Failed default rxgen escape: got \"%s\", expected \"%s\"\n", pat, expected_default);
+        printf("Failed default rxgen escape: got \"%s\", expected \"%s\"\n",
+                pat, expected_default);
         rxgen_release(rx, pat);
         rxgen_close(rx);
         return 1;
     }
     rxgen_release(rx, pat);
 
-    // Test rxgen_set_escape_chars with custom string including out-of-range chars
+    // Test rxgen_set_escape_chars with custom string including out-of-range
+    // chars
     rxgen_reset(rx);
     // Escape '?' and '+' (plus ASCII out-of-range chars 0x01, 0xFF)
     rxgen_set_escape_chars(rx, (const unsigned char *)"\x01?+\xFF");
@@ -45,7 +47,8 @@ test_rxgen(void)
     const char *expected_custom = "a\\+b.c\\?d";
     if (strcmp((const char *)pat, expected_custom) != 0)
     {
-        printf("Failed custom rxgen escape: got \"%s\", expected \"%s\"\n", pat, expected_custom);
+        printf("Failed custom rxgen escape: got \"%s\", expected \"%s\"\n", pat,
+                expected_custom);
         rxgen_release(rx, pat);
         rxgen_close(rx);
         return 1;
@@ -60,7 +63,8 @@ test_rxgen(void)
     const char *expected_empty = "a+b.c\\d";
     if (strcmp((const char *)pat, expected_empty) != 0)
     {
-        printf("Failed empty rxgen escape: got \"%s\", expected \"%s\"\n", pat, expected_empty);
+        printf("Failed empty rxgen escape: got \"%s\", expected \"%s\"\n", pat,
+                expected_empty);
         rxgen_release(rx, pat);
         rxgen_close(rx);
         return 1;
@@ -88,7 +92,9 @@ test_rxgen(void)
     const char *expected_migemo = "a\\+b\\?c.d";
     if (strcmp((const char *)qres, expected_migemo) != 0)
     {
-        printf("Failed migemo custom escape query: got \"%s\", expected \"%s\"\n", qres, expected_migemo);
+        printf("Failed migemo custom escape query: got \"%s\", expected "
+               "\"%s\"\n",
+                qres, expected_migemo);
         migemo_release(mo, qres);
         migemo_close(mo);
         return 1;

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -14,9 +14,7 @@ add_executable(
 
 target_include_directories(
   migemo_wasm
-  PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${PROJECT_BINARY_DIR}/src/include)
+  PRIVATE ${CMAKE_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/src/include)
 
 set_target_properties(
   migemo_wasm


### PR DESCRIPTION
### Summary
This PR refactors the core pattern generator (`rxgen`) for better performance and maintainability, while also refining build configurations and formatting across the project.

### Key Changes
- **`rxgen` Optimization**:
  - Simplified `rnode_dig` using double pointers (`pp`) to streamline node creation/traversal and declared it `inline`.
  - Refactored `rxgen_add` by utilizing `charset_decode` to simplify character decoding and pointer advancement.
- **Robustness & Cleanup**:
  - Gracefully handle invalid UTF-8 byte sequences in `charset_utf8_char2int` by falling back to `charset_none_char2int` (as-is byte decoding).
  - Flattened nested logic in `strbuf_extend` for better readability.
- **Build & Developer Experience**:
  - Cleaned up optimization/debug flags in `CMakeLists.txt` and optimized profiling options (`-pg -fno-omit-frame-pointer`).
  - Added `format-cmake` target to the [Makefile](https://github.com/koron/cmigemo/compare/refactor/rxgen-optimization?expand=1) and adjusted formatting in test code.