### PR TITLE
fix(romaji): prevent duplicate entries and optimize pending node traversal

### DIFF
--- a/dict/roma2hira.dat
+++ b/dict/roma2hira.dat
@@ -371,5 +371,4 @@ nt	ん	t
 nv	ん	v
 nw	ん	w
 nx	ん	x
-ny	ん	y
 nz	ん	z

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -510,22 +510,27 @@ romaji_decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
 }
 
 static wordlist *
-romaji_add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
+romaji_add_pending_node(
+        wordlist *head, wordlist *tail, romanode *node, strbuf *prefix)
 {
     if (!node)
         return tail;
-    tail = romaji_add_pending_node(tail, node->low, prefix);
+    tail = romaji_add_pending_node(head, tail, node->low, prefix);
     if (node->value)
     {
         size_t len = strbuf_len(prefix);
         strbuf_append_str(prefix, node->value);
-        wordlist *item = wordlist_new(strbuf_get(prefix), strbuf_len(prefix));
-        tail->next = item;
-        tail = item;
+        if (!wordlist_contains(head, strbuf_get(prefix)))
+        {
+            wordlist *item =
+                    wordlist_new(strbuf_get(prefix), strbuf_len(prefix));
+            tail->next = item;
+            tail = item;
+        }
         strbuf_truncate(prefix, len);
     }
-    tail = romaji_add_pending_node(tail, node->child, prefix);
-    tail = romaji_add_pending_node(tail, node->high, prefix);
+    tail = romaji_add_pending_node(head, tail, node->child, prefix);
+    tail = romaji_add_pending_node(head, tail, node->high, prefix);
     return tail;
 }
 
@@ -613,7 +618,7 @@ romaji_convert_all(romaji *rj, const unsigned char *src)
         // Output all entries under the pending node.
         wordlist pendings = {0};
         if (node)
-            romaji_add_pending_node(&pendings, node->child, dstbuf);
+            romaji_add_pending_node(&pendings, &pendings, node->child, dstbuf);
         list = pendings.next;
     }
 

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -517,16 +517,12 @@ romaji_add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
     tail = romaji_add_pending_node(tail, node->low, prefix);
     if (node->value)
     {
-        strbuf *w = strbuf_open();
-        if (w)
-        {
-            strbuf_append(w, prefix);
-            strbuf_append_str(w, node->value);
-            wordlist *item = wordlist_new(strbuf_get(w), strbuf_len(w));
-            tail->next = item;
-            tail = item;
-            strbuf_close(w);
-        }
+        size_t len = strbuf_len(prefix);
+        strbuf_append_str(prefix, node->value);
+        wordlist *item = wordlist_new(strbuf_get(prefix), strbuf_len(prefix));
+        tail->next = item;
+        tail = item;
+        strbuf_truncate(prefix, len);
     }
     tail = romaji_add_pending_node(tail, node->child, prefix);
     tail = romaji_add_pending_node(tail, node->high, prefix);

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -536,6 +536,9 @@ romaji_add_pending_node(wordlist *tail, romanode *node, strbuf *prefix)
 wordlist *
 romaji_convert_all(romaji *rj, const unsigned char *src)
 {
+    if (!rj->rootnode)
+        return NULL;
+
     wordlist *list = NULL;
     unsigned char *srcbuf = NULL;
     strbuf *dstbuf = NULL;

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -117,3 +117,13 @@ strbuf_append_mem(strbuf *sb, const unsigned char *p, size_t len)
     }
     return sb->len;
 }
+
+size_t
+strbuf_truncate(strbuf *sb, size_t len)
+{
+    if (len >= sb->len)
+        return sb->len;
+    sb->buf[len] = '\0';
+    sb->len = len;
+    return len;
+}

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -29,6 +29,9 @@ size_t strbuf_append_ch(strbuf *sb, unsigned char ch);
 size_t strbuf_append_str(strbuf *sb, const unsigned char *s);
 size_t strbuf_append_mem(strbuf *sb, const unsigned char *p, size_t len);
 
+// Others
+size_t strbuf_truncate(strbuf *sb, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -41,3 +41,12 @@ wordlist_destroy(wordlist *wl)
         wl = next;
     }
 }
+
+bool
+wordlist_contains(wordlist *wl, const unsigned char *str)
+{
+    for (; wl; wl = wl->next)
+        if (!strcmp(wl->ptr, str))
+            return true;
+    return false;
+}

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 typedef struct wordlist wordlist;
 struct wordlist
 {
@@ -20,6 +22,9 @@ extern "C" {
 // Life cycle management
 wordlist *wordlist_new(const unsigned char *ptr, size_t len);
 void wordlist_destroy(wordlist *wl);
+
+// Others
+bool wordlist_contains(wordlist *wl, const unsigned char *str);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Summary
This PR fixes an issue where identical unconverted queries and candidates were duplicated when converting romaji inputs. It also optimizes string buffer management during pending node traversal.

### Key Changes
- **Fix duplication when dictionary is uninitialized**: Return `NULL` early in `romaji_convert_all()` if `rj->rootnode` is missing.
- **Optimize buffer usage**: Introduced `strbuf_truncate()` to allow `romaji_add_pending_node()` to reuse the existing `prefix` buffer instead of allocating new buffers per node.
- **Deduplicate pending candidates**: Added `wordlist_contains()` to prevent duplicate entries from being registered across different tree branches.
- **Fix dictionary conflict**: Removed the redundant `ny` -> `ん` + `y` mapping from `roma2hira.dat` to avoid conflicts with 拗音 (contracted sound) rules such as `nya` and `nyo`.