### PR TITLE
docs: add OKF directory indexes for repository navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 
 ## Project Structure
 
+- OKF Indexing: Each main directory contains an `index.md` (Open Knowledge Format) acting as a directory map. ALWAYS read the relevant `index.md` first to locate source files efficiently before performing broad searches.
 - `include/migemo.h.in` - public C API template; generated to `build/src/include/migemo.h` at configure time; version comes from `project(VERSION)` in top-level `CMakeLists.txt` (matches CMake project version)
 - `src/migemo.c`, `rxgen.c`, `romaji.c`, `charset.c`, `strbuf.c`, `wordlist.c`, `mtree.c`, `trie.c`, `filename.c` - core shared library (`migemo`)
 - `src/main.c` - CLI executable (`cmigemo`)

--- a/dict/index.md
+++ b/dict/index.md
@@ -1,0 +1,26 @@
+---
+type: Directory Index
+title: "dict Index"
+description: "Dictionary build scripts and static .dat conversion tables used to generate the migemo-dict dictionaries."
+tags: [index]
+---
+
+# Overview
+
+This directory holds the dictionary build pipeline for cmigemo: Perl scripts that convert the SKK-JISYO Japanese dictionary into migemo format and optimize it, the static sub-dictionaries (Romaji/hiragana conversion, character width conversions), and the CMake rules that orchestrate the download-and-build process.
+
+# Directory Contents
+
+| File / Path | Type | Description |
+| :--- | :--- | :--- |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that download SKK-JISYO.L and run the conversion scripts to build the per-encoding dictionaries. |
+| [skk2migemo.pl](./skk2migemo.pl) | Script | Perl script that converts the SKK-JISYO dictionary into migemo-dict format. |
+| [optimize-dict.pl](./optimize-dict.pl) | Script | Perl script that optimizes migemo-dict so the C/Migemo library can load it. |
+| [roma2hira.dat](./roma2hira.dat) | Data | Table to convert Romaji input to HIRAGANA in Japanese. |
+| [hira2kata.dat](./hira2kata.dat) | Data | HIRAGANA-to-Katakana (平仮名→カタカナ) conversion table. |
+| [han2zen.dat](./han2zen.dat) | Data | Half-width-to-full-width (半角→全角) character conversion table. |
+| [zen2han.dat](./zen2han.dat) | Data | Full-width-to-half-width (全角→半角) character conversion table. |
+| [migemo-dict-zh](./migemo-dict-zh) | Data | Chinese (zh) migemo dictionary copied into the utf-8 dictionary build. |
+
+# References
+- [Parent Directory](../index.md)

--- a/index.md
+++ b/index.md
@@ -1,0 +1,36 @@
+---
+type: Directory Index
+title: "cmigemo Index"
+description: "Repository root of C/Migemo, a C library for generating Japanese regexp patterns from Romaji input."
+tags: [index]
+---
+
+# Overview
+
+This is the root of the C/Migemo project: a C-language implementation of Migemo that converts Romaji input into regular expressions for incremental Japanese text searching, along with its CMake build system, dictionary generation scripts, tests, and documentation.
+
+# Directory Contents
+
+| File / Path | Type | Description |
+| :--- | :--- | :--- |
+| [README.md](./README.md) | Document | Project introduction explaining C/Migemo and its usage. |
+| [AGENTS.md](./AGENTS.md) | Document | Instructions for AI agents covering build, test, and coding conventions. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | Top-level CMake project definition for the cmigemo library, tools, and tests. |
+| [Makefile](./Makefile) | Build | Convenience shortcuts wrapping CMake targets such as build, test, and format. |
+| [LICENSE](./LICENSE) | Document | License text for the project. |
+| [tags](./tags) | Build Support | Generated ctags index for code navigation. |
+| [.clang-format](./.clang-format) | Configuration | clang-format style rules for the C sources. |
+| [.cmakefmt.yaml](./.cmakefmt.yaml) | Configuration | cmakefmt formatting rules for CMakeLists files. |
+| [.gitignore](./.gitignore) | Configuration | Git exclusion rules for generated build output. |
+| [src/](./src/index.md) | Directory Index | Source files for the cmigemo core shared library (migemo) and its CLI tool, plus auxiliary build/test tools. |
+| [test/](./test/) | Directory Index | CTest suite (test1) and fixtures verifying the migemo library. |
+| [dict/](./dict/) | Directory Index | Dictionary build scripts and static sub-dictionaries for generating migemo-dict. |
+| [doc/](./doc/) | Directory Index | Japanese documentation and Doxygen configuration. |
+| [include/](./include/) | Directory Index | Public header template (migemo.h.in) installed at build time. |
+| [misc/](./misc/) | Directory Index | Reference C# wrapper and a vim plugin, not part of the build. |
+| [wasm/](./wasm/) | Directory Index | WebAssembly build and test assets for the cmigemo library. |
+| [.github/](./.github/) | Directory Index | GitHub configuration including dependabot and CI workflow definitions. |
+
+# References
+- [Agent Guidelines](./AGENTS.md)
+- [Project Readme](./README.md)

--- a/src/index.md
+++ b/src/index.md
@@ -1,0 +1,42 @@
+---
+type: Directory Index
+title: "src Index"
+description: "Source files for the cmigemo core shared library (migemo) and its CLI tool, plus auxiliary build/test tools."
+tags: [index]
+---
+
+# Overview
+
+This directory contains the C sources, headers, and CMake build scripts for the `migemo` shared library and the `cmigemo` CLI executable, along with the `testdir` folder holding auxiliary tools (`romaji`, `qspeed`) that are built outside the core library.
+
+# Directory Contents
+
+| File / Path | Type | Description |
+| :--- | :--- | :--- |
+| [main.c](./main.c) | Source | Entry point of the `cmigemo` CLI binary that drives the migemo library. |
+| [migemo.c](./migemo.c) | Source | Core migemo public API implementation (library and dictionary loading). |
+| [migemo_struct.h](./migemo_struct.h) | Header | Internal struct definitions shared across the core library. |
+| [rxgen.c](./rxgen.c) | Source | Regular expression generator for matching input against the migemo dictionary. |
+| [rxgen.h](./rxgen.h) | Header | Public declarations of the regular expression generator. |
+| [romaji.c](./romaji.c) | Source | Romaji (romajikana) conversion support for input handling. |
+| [romaji.h](./romaji.h) | Header | Public declarations of the romaji conversion module. |
+| [charset.c](./charset.c) | Source | Character set and multi-byte encoding conversion helpers. |
+| [charset.h](./charset.h) | Header | Public declarations of the character set conversion module. |
+| [strbuf.c](./strbuf.c) | Source | Dynamic string buffer implementation used throughout the library. |
+| [strbuf.h](./strbuf.h) | Header | Public declarations of the string buffer module. |
+| [trie.c](./trie.c) | Source | Trie data structure used for dictionary storage and lookup. |
+| [trie.h](./trie.h) | Header | Public declarations of the trie data structure. |
+| [mtree.c](./mtree.c) | Source | Migemo tree (mtree) operations for building and searching the trie. |
+| [mtree.h](./mtree.h) | Header | Public declarations of the migemo tree operations. |
+| [wordlist.c](./wordlist.c) | Source | Word list handling for dictionary expansion. |
+| [wordlist.h](./wordlist.h) | Header | Public declarations of the word list module. |
+| [filename.c](./filename.c) | Source | Filename manipulation helpers for locating dictionaries. |
+| [filename.h](./filename.h) | Header | Public declarations of the filename helper module. |
+| [common.h](./common.h) | Header | Shared code (e.g., debugging facilities) injected into all .c files. |
+| [migemo.def](./migemo.def) | Build Support | MSVC module definition file controlling exported library symbols. |
+| [migemo.rc.in](./migemo.rc.in) | Build Support | CMake template generating the Windows resource file for the library. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake build rules for the migemo library, cmigemo binary, and tools. |
+| [testdir/](./testdir/) | Directory Index | Auxiliary tools built from this directory: the `romaji` command, the `qspeed` benchmark driver, and gprof support. |
+
+# References
+- [Parent Directory](../index.md)

--- a/test/index.md
+++ b/test/index.md
@@ -1,0 +1,23 @@
+---
+type: Directory Index
+title: "test Index"
+description: "CTest test suite (test1) with C test sources verifying the migemo library and its fixtures."
+tags: [index]
+---
+
+# Overview
+
+This directory contains the executable-based test suite for the cmigemo library: a CMake target that builds the `test1` binary from multiple C test files, registered with CTest, and run against a static migemo-dict fixture.
+
+# Directory Contents
+
+| File / Path | Type | Description |
+| :--- | :--- | :--- |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that build the `test1` executable and register the CTest suite. |
+| [main.c](./main.c) | Source | Test runner entry point that invokes the individual test functions. |
+| [test1.c](./test1.c) | Source | Main library test that loads the dictionary fixture and checks migemo conversion. |
+| [test_rxgen.c](./test_rxgen.c) | Source | Test of the regular expression generator (rxgen) module. |
+| [test1/](./test1/) | Directory Index | Test fixture directory holding the static `migemo-dict` file used by the tests. |
+
+# References
+- [Parent Directory](../index.md)

--- a/wasm/index.md
+++ b/wasm/index.md
@@ -1,0 +1,25 @@
+---
+type: Directory Index
+title: "wasm Index"
+description: "WebAssembly build of the cmigemo library with emscripten wrappers and a browser test page."
+tags: [index]
+---
+
+# Overview
+
+This directory contains a standalone CMake build that compiles the cmigemo library to WebAssembly, along with the emscripten-generated JS wrapper, browser-side JS entry points, and a small HTML test harness.
+
+# Directory Contents
+
+| File / Path | Type | Description |
+| :--- | :--- | :--- |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | Standalone CMake rules that build the migemo_wasm executable with Emscripten. |
+| [index.js](./index.js) | Source | Browser/Node entry point that loads and instantiates the migemo WebAssembly module. |
+| [library.js](./library.js) | Source | Emscripten library function definitions linked into the WASM module. |
+| [migemo_wasm.js](./migemo_wasm.js) | Build Output | Emscripten-generated JavaScript loader for the compiled WASM module. |
+| [migemo_wasm.wasm](./migemo_wasm.wasm) | Build Output | Compiled WebAssembly binary of the migemo library. |
+| [.gitignore](./.gitignore) | Configuration | Git exclusion rules keeping the generated WASM build artifacts out of version control. |
+| [test/](./test/) | Directory Index | Browser test harness (HTML page and JS) for the WASM build. |
+
+# References
+- [Parent Directory](../index.md)


### PR DESCRIPTION
Add `index.md` files across key directories (`/`, `src/`, `test/`, `dict/`, `wasm/`) following the Open Knowledge Format (OKF) specification to improve directory navigation and context understanding for AI agents.

### Changes
- Include frontmatter metadata (`type`, `title`, `description`, `tags`) for each directory index.
- Provide structured markdown tables mapping files to their types and descriptions for clear context grounding.
- Exclude build artifacts and temporary directories (`build/`, `lib/`, `tmp/`) to avoid broken links and unnecessary noise.
- Add cross-references to `AGENTS.md` and `README.md` at the root index.