### PR TITLE
refactor(migemo): optimize query processing with inlined charset_decode

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -14,14 +14,6 @@
 #include "charset.h"
 
 int
-charset_none_char2int(const unsigned char *in, unsigned int *out)
-{
-    if (out)
-        *out = *in;
-    return 1;
-}
-
-int
 charset_none_int2char(unsigned int in, unsigned char *out)
 {
     if (out)
@@ -100,53 +92,34 @@ charset_eucjp_int2char(unsigned int in, unsigned char *out)
     return 1;
 }
 
+// Use LUT to determine number of continuation bytes in UTF-8.
+// clang-format off
+const unsigned char CHARSET_UTF8_LUT[128] = {
+        // 0x80 - 0xBF: invalid sequence (continuation byte without leader)
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // 0xC0 - 0xC1: invalid (overlong encoding)
+        0, 0,
+        // 0xC2 - 0xDF (110xxxxx): 2 bytes character
+              2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        // 0xE0 - 0xEF (1110xxxx): 3 bytes character
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        // 0xF0 - 0xF7 (11110xxx): 4 bytes character
+        4, 4, 4, 4, 4,
+        // 0xF5 - 0xF7: invalid (exceeding Unicode max value of U+10FFFF)
+                       0, 0, 0,
+        // 0xF8 - 0xFF (11111xxx or greater): invalid values.
+                                0, 0, 0, 0, 0, 0, 0, 0,
+};
+// clang-format on
+
 int
 charset_utf8_char2int(const unsigned char *in, unsigned int *out)
 {
-    if (!(in[0] & 0x80))
-        return charset_none_char2int(in, out);
-
-    // Use LUT to determine number of continuation bytes in UTF-8.
-    // clang-format off
-    static const unsigned char UTF8_LUT[128] = {
-            // 0x80 - 0xBF: invalid sequence (continuation byte without leader)
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            // 0xC0 - 0xC1: invalid (overlong encoding)
-            0, 0,
-            // 0xC2 - 0xDF (110xxxxx): 2 bytes character
-                  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-            // 0xE0 - 0xEF (1110xxxx): 3 bytes character
-            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-            // 0xF0 - 0xF7 (11110xxx): 4 bytes character
-            4, 4, 4, 4, 4,
-            // 0xF5 - 0xF7: invalid (exceeding Unicode max value of U+10FFFF)
-                           0, 0, 0,
-            // 0xF8 - 0xFF (11111xxx or greater): invalid values.
-                                    0, 0, 0, 0, 0, 0, 0, 0,
-    };
-    // clang-format on
-    int len = UTF8_LUT[in[0] - 128];
-    if (!len)
-        // Output an invalid byte as-is.
-        return charset_none_char2int(in, out);
-
-    unsigned int code = in[0] & (0xff >> len);
-    for (int i = 1; i < len; ++i)
-    {
-        // check invalid byte.
-        if ((in[i] & 0xc0) != 0x80)
-            // Output an invalid byte as-is.
-            return charset_none_char2int(in, out);
-        code <<= 6;
-        code += in[i] & 0x3f;
-    }
-    if (out)
-        *out = code;
-    return len;
+    return charset_utf8_char2int_inner(in, out);
 }
 
 int

--- a/src/charset.h
+++ b/src/charset.h
@@ -21,11 +21,12 @@ typedef int (*charset_proc_int2char)(unsigned int, unsigned char *);
 #define CHARSET_PROC_CHAR2INT charset_proc_char2int
 #define CHARSET_PROC_INT2CHAR charset_proc_int2char
 
+extern const unsigned char CHARSET_UTF8_LUT[128];
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int charset_none_char2int(const unsigned char *in, unsigned int *out);
 int charset_none_int2char(unsigned int in, unsigned char *out);
 
 int charset_cp932_char2int(const unsigned char *in, unsigned int *out);
@@ -43,10 +44,45 @@ void charset_getproc(int charset, CHARSET_PROC_CHAR2INT *char2int,
 }
 #endif
 
+static inline int
+charset_none_char2int(const unsigned char *in, unsigned int *out)
+{
+    if (out)
+        *out = *in;
+    return 1;
+}
+
+
+static inline int
+charset_utf8_char2int_inner(const unsigned char *in, unsigned int *out)
+{
+    if (!(in[0] & 0x80))
+        return charset_none_char2int(in, out);
+
+    int len = CHARSET_UTF8_LUT[in[0] - 128];
+    if (!len)
+        // Output an invalid byte as-is.
+        return charset_none_char2int(in, out);
+
+    unsigned int code = in[0] & (0xff >> len);
+    for (int i = 1; i < len; ++i)
+    {
+        // check invalid byte.
+        if ((in[i] & 0xc0) != 0x80)
+            // Output an invalid byte as-is.
+            return charset_none_char2int(in, out);
+        code <<= 6;
+        code += in[i] & 0x3f;
+    }
+    if (out)
+        *out = code;
+    return len;
+}
+
 static inline unsigned int
 charset_decode(CHARSET_PROC_CHAR2INT proc, const unsigned char **pptr)
 {
     unsigned int code = 0;
-    *pptr += proc ? proc(*pptr, &code) : charset_utf8_char2int(*pptr, &code);
+    *pptr += proc ? proc(*pptr, &code) : charset_utf8_char2int_inner(*pptr, &code);
     return code;
 }

--- a/src/charset.h
+++ b/src/charset.h
@@ -47,6 +47,6 @@ static inline unsigned int
 charset_decode(CHARSET_PROC_CHAR2INT proc, const unsigned char **pptr)
 {
     unsigned int code = 0;
-    *pptr += proc(*pptr, &code);
+    *pptr += proc ? proc(*pptr, &code) : charset_utf8_char2int(*pptr, &code);
     return code;
 }

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -51,7 +51,8 @@ load_mtree_dictionary(migemo *mo, const char *dict_file)
     charset_getproc(mo->charset, &char2int, &int2char);
     migemo_setproc_char2int(mo, (MIGEMO_PROC_CHAR2INT)char2int);
     migemo_setproc_int2char(mo, (MIGEMO_PROC_INT2CHAR)int2char);
-    mo->char2int = char2int;
+    mo->char2int =
+            char2int && char2int != charset_utf8_char2int ? char2int : NULL;
 
     FILE *fp = fopen(dict_file, "rt");
     if (!fp)
@@ -135,7 +136,7 @@ migemo_open(const char *dict)
     mo->hira2kata = romaji_open();
     mo->han2zen = romaji_open();
     mo->zen2han = romaji_open();
-    mo->char2int = charset_none_char2int;
+    mo->char2int = NULL;
     if (!mo->mtree || !mo->rx || !mo->roma2hira || !mo->hira2kata
             || !mo->han2zen || !mo->zen2han)
     {
@@ -273,38 +274,47 @@ migemo_add_roma_variants(migemo *mo, unsigned char *query)
 static wordlist *
 migemo_segment_query(migemo *mo, const unsigned char *query)
 {
-    const unsigned char *curr = query;
-    const unsigned char *start = NULL;
-    wordlist *queries = NULL, **pp = &queries;
-
-    while (1)
+    wordlist *queries = NULL, **pnext = &queries;
+    const unsigned char *r = query;
+    for (bool loop = true; loop;)
     {
-        int len, upper;
-        int sum = 0;
+        const unsigned char *start = r;
 
-        if (!mo->char2int || (len = mo->char2int(curr, NULL)) < 1)
-            len = 1;
-        start = curr;
-        upper = (len == 1 && isupper(*curr) && isupper(curr[1]));
-        curr += len;
-        sum += len;
+        // Determine how to identify query boundaries.
+        bool upper_mode = false;
+        int first = charset_decode(mo->char2int, &r);
+        if (first < 0x80 && isupper(first))
+        {
+            // Look ahead to the second character.
+            const unsigned char *r2 = r;
+            int second = charset_decode(mo->char2int, &r2);
+            upper_mode = second < 0x80 && isupper(second);
+        }
+
+        // Locate the boundary where the case switches. In "upper mode," the
+        // first lowercase letter marks the boundary; in "lower mode," the
+        // first uppercase letter marks the boundary.
+        const unsigned char *prev = NULL;
         while (1)
         {
-            if (!mo->char2int || (len = mo->char2int(curr, NULL)) < 1)
-                len = 1;
-            if (*curr == '\0' || (len == 1 && (isupper(*curr) != 0) != upper))
+            prev = r;
+            int code = charset_decode(mo->char2int, &r);
+            if (code == 0)
+            {
+                loop = false;
                 break;
-            curr += len;
-            sum += len;
+            }
+            if (code < 0x80 && (isupper(code) != 0) != upper_mode)
+                break;
         }
+
         // Register a phrase
-        if (start && start < curr)
+        if (prev)
         {
-            *pp = wordlist_new(start, sum);
-            pp = &(*pp)->next;
+            *pnext = wordlist_new(start, prev - start);
+            pnext = &(*pnext)->next;
+            r = prev;
         }
-        if (*curr == '\0')
-            break;
     }
     return queries;
 }

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -8,6 +8,7 @@
 
 #include <ctype.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -338,7 +339,7 @@ migemo_process_word(migemo *mo, unsigned char *query)
     {
         const unsigned char *prev = r;
         int code = charset_decode(mo->char2int, &r);
-        off_t step = r - prev;
+        ptrdiff_t step = r - prev;
         if (step == 1 && code < 0x80 && isupper(code))
             *w = (unsigned char)tolower(code);
         else

--- a/src/migemo.c
+++ b/src/migemo.c
@@ -321,17 +321,24 @@ migemo_process_word(migemo *mo, unsigned char *query)
     // Naturally, add the query itself to the candidates
     migemo_add_word(mo, query);
 
-    // Dictionary search using a lowercase query.
-    for (int i = 0, step; i <= len; i += step)
+    // Convert the query string to lowercase.
+    const unsigned char *r = query;
+    unsigned char *w = lower;
+    while (1)
     {
-        // Uppercase to lowercase conversion considering multi-byte characters
-        if (!mo->char2int || (step = mo->char2int(&query[i], NULL)) < 1)
-            step = 1;
-        if (step == 1 && isupper(query[i]))
-            lower[i] = (unsigned char)tolower(query[i]);
+        const unsigned char *prev = r;
+        int code = charset_decode(mo->char2int, &r);
+        off_t step = r - prev;
+        if (step == 1 && code < 0x80 && isupper(code))
+            *w = (unsigned char)tolower(code);
         else
-            memcpy(&lower[i], &query[i], step);
+            memcpy(w, prev, step);
+        if (code == 0)
+            break;
+        w += step;
     }
+
+    // Dictionary search using a lowercase query.
     migemo_add_mtree_matches(mo, lower);
 
     // Convert query to full-width and add to candidates

--- a/src/mtree.c
+++ b/src/mtree.c
@@ -149,25 +149,12 @@ mtree_close(mtree *mt)
     }
 }
 
-// decode_rune decodes a single rune from a string. Returns the number of bytes
-// consumed. Always consumes one byte, even for invalid byte sequences.
-static inline int
-decode_rune(mtree *mt, const unsigned char **pp)
-{
-    unsigned int code = 0;
-    int len = mt->char2int(*pp, &code);
-    if (len == 0)
-        len = charset_none_char2int(*pp, &code);
-    *pp += len;
-    return code;
-}
-
 static inline mnode *
 mtree_ensure_node(mtree *mt, const unsigned char *key)
 {
     if (!key)
         return NULL;
-    unsigned int code = decode_rune(mt, &key);
+    unsigned int code = charset_decode(mt->char2int, &key);
     if (code == 0)
         return NULL;
 
@@ -198,7 +185,7 @@ mtree_ensure_node(mtree *mt, const unsigned char *key)
         }
         ppnext = &(*res)->child;
         (*res)->weight++;
-        code = decode_rune(mt, &key);
+        code = charset_decode(mt->char2int, &key);
         if (code == 0)
             break;
     }
@@ -353,8 +340,8 @@ mtree_readline(mtree_file *mf, size_t *line_len)
 mtree *
 mtree_load(mtree *mt, FILE *fp, CHARSET_PROC_CHAR2INT char2int)
 {
-    if (char2int)
-        mt->char2int = char2int;
+    mt->char2int =
+            char2int && char2int != charset_utf8_char2int ? char2int : NULL;
 
     mtree_file mf = {.fp = fp, .read_request = true};
     while (1)
@@ -432,7 +419,7 @@ mtree_open(void)
 {
     mtree *mt = (mtree *)calloc(1, sizeof(*mt));
     // Set the default to UTF-8.
-    mt->char2int = charset_utf8_char2int;
+    mt->char2int = NULL;
     return mt;
 }
 
@@ -442,7 +429,7 @@ mtree_query(mtree *mt, const unsigned char *query)
     if (!mt || !mt->rootnode || !query)
         return NULL;
 
-    unsigned int code = decode_rune(mt, &query);
+    unsigned int code = charset_decode(mt->char2int, &query);
     if (code == 0)
         return NULL;
     mnode *node = mt->rootnode;
@@ -455,7 +442,7 @@ mtree_query(mtree *mt, const unsigned char *query)
         if (!node)
             break; // Not found the rune.
         // Proceed to the child node
-        code = decode_rune(mt, &query);
+        code = charset_decode(mt->char2int, &query);
         if (code == 0)
             break; // Found the node.
         node = node->child;

--- a/src/romaji.c
+++ b/src/romaji.c
@@ -183,7 +183,7 @@ romaji_open()
     romaji *rj = (romaji *)calloc(1, sizeof(romaji));
     if (!rj)
         return NULL;
-    rj->char2int = charset_none_char2int;
+    rj->char2int = NULL;
     return rj;
 }
 
@@ -472,7 +472,7 @@ romaji_load(romaji *rj, const unsigned char *filename,
 {
     if (!rj || !filename)
         return -1;
-    rj->char2int = char2int;
+    rj->char2int = char2int && char2int != charset_utf8_char2int ? char2int : NULL;
     FILE *fp = fopen(filename, "rt");
     if (!fp)
         return -1;
@@ -505,8 +505,9 @@ romaji_find_siblings(romaji *rj, romanode *node, unsigned int code)
 static inline size_t
 romaji_decode_len(CHARSET_PROC_CHAR2INT proc, const unsigned char *s)
 {
-    int len = proc(s, NULL);
-    return len > 0 ? (size_t)len : 1;
+    const unsigned char *p = s;
+    charset_decode(proc, &p);
+    return p - s;
 }
 
 static wordlist *

--- a/src/rxgen.c
+++ b/src/rxgen.c
@@ -120,8 +120,9 @@ rnode_arena_free(rnode_arena *arena)
 void
 rxgen_setproc_char2int(rxgen *rx, CHARSET_PROC_CHAR2INT proc)
 {
-    if (rx)
-        rx->char2int = proc ? proc : charset_none_char2int;
+    if (!rx)
+        return;
+    rx->char2int = proc && proc != charset_utf8_char2int ? proc : NULL;
 }
 
 void


### PR DESCRIPTION
## Summary
Refactors query processing routines (`migemo_process_word` and `migemo_segment_query`) to utilize `charset_decode` and stream-based pointer operations instead of manual step calculations and indirect `char2int` calls.

## Key Changes
- **Query Lowercasing (`migemo_process_word`)**:
  - Replaced indirect `mo->char2int` calls with inlined `charset_decode`.
  - Added strict ASCII checking (`code < 0x80`) before calling `isupper` / `tolower` to ensure locale-independent and safe multi-byte processing.
  - Simplified string manipulation using direct pointer traversal (`r` / `w`).

- **Query Segmentation (`migemo_segment_query`)**:
  - Refactored camel-case boundary detection to leverage `charset_decode` for character-by-character processing.
  - Implemented look-ahead decoding (`r2`) to cleanly identify consecutive uppercase sequences without modifying the main stream pointer.
  - Optimized list construction using double pointers (`pnext`) for $O(1)$ node insertion.
  - Ensured `mo->char2int` defaults to `NULL` for UTF-8 in `migemo_open`, enabling fast inline execution path.

## Benefits
- Eliminates indirect function call overhead on hot paths, benefiting directly from the previously introduced `charset_decode` inline optimizations.
- Improves code readability, robustness, and character boundary handling across multi-byte strings.