### PR TITLE
docs: update OKF directory indexes

### DIFF
--- a/bench/index.md
+++ b/bench/index.md
@@ -1,21 +1,21 @@
 ---
 type: Directory Index
 title: "bench Index"
-description: "Benchmark and profiling programs that measure migemo dictionary load and single-character query speed."
+description: "Benchmark and profiling tools for measuring migemo dictionary load and query performance."
 tags: [index]
 ---
 
 # Overview
-
-This directory contains the profiling build of the migemo library and a benchmark program that repeatedly queries single characters to measure query performance, producing a `profile.log` via gprof.
+Contains CMake build rules and C benchmark programs for profiling the migemo library's dictionary loading (`migemo_open`) and single-character query performance, with `gprof` integration for call-graph analysis.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that build the profiling library, the profile_char_query executable, and the profile custom target. |
-| [copy_gmon.cmake](./copy_gmon.cmake) | Build Support | CMake script that copies the qspeed gmon output file to gmon.out for gprof. |
-| [profile_char_query.c](./profile_char_query.c) | Source | Benchmark program that times dictionary loading and single-character migemo queries. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build Script | Defines the `migemo_profile` static library and `profile_char_query`/`profile_migemo_open` executables with gprof instrumentation. |
+| [copy_gmon.cmake](./copy_gmon.cmake) | Build Script | CMake policy script that copies `qspeed.gmon` to `gmon.out` for gprof consumption. |
+| [profile_char_query.c](./profile_char_query.c) | Benchmark | Measures the time for single-character `migemo_query` calls across the alphabet over multiple trials. |
+| [profile_migemo_open.c](./profile_migemo_open.c) | Benchmark | Measures the time for repeated `migemo_open`/`migemo_close` dictionary load cycles. |
 
 # References
 - [Parent Directory](../index.md)

--- a/dict/index.md
+++ b/dict/index.md
@@ -1,26 +1,25 @@
 ---
 type: Directory Index
 title: "dict Index"
-description: "Dictionary build scripts and static .dat conversion tables used to generate the migemo-dict dictionaries."
+description: "Dictionary sources for C/Migemo: build script, Perl conversion/optimization tools, static Japanese conversion tables, and a Chinese dictionary."
 tags: [index]
 ---
 
 # Overview
-
-This directory holds the dictionary build pipeline for cmigemo: Perl scripts that convert the SKK-JISYO Japanese dictionary into migemo format and optimize it, the static sub-dictionaries (Romaji/hiragana conversion, character width conversions), and the CMake rules that orchestrate the download-and-build process.
+This directory holds the dictionary sources used by C/Migemo: the CMake build that downloads SKK-JISYO.L and produces the `migemo-dict` files per encoding, Perl scripts that convert and optimize the dictionary, the static `.dat` tables for Japanese character conversions, and the bundled Chinese dictionary.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that download SKK-JISYO.L and run the conversion scripts to build the per-encoding dictionaries. |
-| [skk2migemo.pl](./skk2migemo.pl) | Script | Perl script that converts the SKK-JISYO dictionary into migemo-dict format. |
-| [optimize-dict.pl](./optimize-dict.pl) | Script | Perl script that optimizes migemo-dict so the C/Migemo library can load it. |
-| [roma2hira.dat](./roma2hira.dat) | Data | Table to convert Romaji input to HIRAGANA in Japanese. |
-| [hira2kata.dat](./hira2kata.dat) | Data | HIRAGANA-to-Katakana (平仮名→カタカナ) conversion table. |
-| [han2zen.dat](./han2zen.dat) | Data | Half-width-to-full-width (半角→全角) character conversion table. |
-| [zen2han.dat](./zen2han.dat) | Data | Full-width-to-half-width (全角→半角) character conversion table. |
-| [migemo-dict-zh](./migemo-dict-zh) | Data | Chinese (zh) migemo dictionary copied into the utf-8 dictionary build. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake script that downloads SKK-JISYO.L and builds the `migemo-dict` files for the utf-8, euc-jp, and cp932 encodings. |
+| [han2zen.dat](./han2zen.dat) | Data | Half-width to full-width character conversion table. |
+| [hira2kata.dat](./hira2kata.dat) | Data | Hiragana to Katakana conversion table. |
+| [migemo-dict-zh](./migemo-dict-zh) | Data | Chinese dictionary mapping pinyin syllables to Chinese characters. |
+| [optimize-dict.pl](./optimize-dict.pl) | Script | Perl script that rebalances dictionary entries in DFS midpoint order so C/Migemo can load the dictionary efficiently. |
+| [roma2hira.dat](./roma2hira.dat) | Data | Table to convert Japanese ROMAJI to HIRAGANA. |
+| [skk2migemo.pl](./skk2migemo.pl) | Script | Perl script that converts SKK-JISYO data into tab-separated migemo-dict lines. |
+| [zen2han.dat](./zen2han.dat) | Data | Full-width to half-width character conversion table. |
 
 # References
 - [Parent Directory](../index.md)

--- a/index.md
+++ b/index.md
@@ -1,38 +1,32 @@
 ---
 type: Directory Index
 title: "cmigemo Index"
-description: "Repository root of C/Migemo, a C library for generating Japanese regexp patterns from Romaji input."
+description: "C/Migemo regexp generator library: a CMake C11 project bundling the migemo shared library, dictionary sources, CTest suite, benchmarks, console tools, and a WebAssembly port."
 tags: [index]
 ---
 
 # Overview
-
-This is the root of the C/Migemo project: a C-language implementation of Migemo that converts Romaji input into regular expressions for incremental Japanese text searching, along with its CMake build system, dictionary generation, benchmarks, tools, tests, and documentation.
+C/Migemo is a C-language implementation of Migemo, a regexp pattern generator/expander that converts Romaji input into regular expressions for incremental Japanese text searches. This root directory contains the CMake build, the shared library sources, dictionary sources, the CTest suite, benchmarking, console driver tools, and a WebAssembly port.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [README.md](./README.md) | Document | Project introduction explaining C/Migemo and its build and usage. |
-| [AGENTS.md](./AGENTS.md) | Document | Instructions for AI agents covering build, test, and coding conventions. |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | Top-level CMake project definition for the cmigemo library, tools, and tests. |
-| [Makefile](./Makefile) | Build | Convenience shortcuts wrapping CMake targets such as build, test, and format. |
-| [LICENSE](./LICENSE) | Document | License text for the project. |
-| [tags](./tags) | Build Support | Generated ctags index for code navigation. |
-| [.clang-format](./.clang-format) | Configuration | clang-format style rules for the C sources. |
-| [.cmakefmt.yaml](./.cmakefmt.yaml) | Configuration | cmakefmt formatting rules for CMakeLists files. |
-| [.gitignore](./.gitignore) | Configuration | Git exclusion rules for generated build output. |
-| [src/](./src/index.md) | Directory Index | Source files for the cmigemo core shared library (migemo) and its CLI tool, plus auxiliary build/test tools. |
-| [tools/](./tools/) | Directory | CMake build definitions and sources for the cmigemo and romaji command-line tools. |
-| [bench/](./bench/) | Directory | Benchmark and profiling programs for character query speed measurement. |
-| [test/](./test/index.md) | Directory Index | CTest test suite (test1) with C test sources verifying the migemo library and its fixtures. |
-| [dict/](./dict/index.md) | Directory Index | Dictionary build scripts and static .dat conversion tables used to generate the migemo-dict dictionaries. |
-| [doc/](./doc/) | Directory | Japanese documentation and Doxygen configuration. |
-| [include/](./include/) | Directory | Public header template (migemo.h.in) installed at build time. |
-| [misc/](./misc/) | Directory | Reference C# wrapper and a vim plugin, not part of the build. |
-| [wasm/](./wasm/index.md) | Directory Index | WebAssembly build of the cmigemo library with emscripten wrappers and a browser test page. |
-| [.github/](./.github/) | Directory | GitHub configuration including dependabot and CI workflow definitions. |
-
-# References
-- [Agent Guidelines](./AGENTS.md)
-- [Project Readme](./README.md)
+| [CMakeLists.txt](./CMakeLists.txt) | Build Script | Top-level CMake build definition for the C/Migemo project. |
+| [Makefile](./Makefile) | Build Script | Convenience make targets wrapping the CMake build (build, test, profile, package). |
+| [README.md](./README.md) | Documentation | Project overview and usage documentation for the C/Migemo library. |
+| [AGENTS.md](./AGENTS.md) | Agent Guide | AI-agent guidance covering build, test, dictionary, and project conventions. |
+| [LICENSE](./LICENSE) | Legal | License text for C/Migemo. |
+| [.clang-format](./.clang-format) | Config | clang-format configuration for the C sources. |
+| [.cmakefmt.yaml](./.cmakefmt.yaml) | Config | cmakefmt configuration for CMake formatting. |
+| [.gitignore](./.gitignore) | Config | Git ignore rules for build outputs and generated files. |
+| [src/](./src/index.md) | Directory Index | C sources and headers for the migemo shared library core (dictionary tree, romaji, regexp, charset), with CMake build rules and Windows build support files. |
+| [dict/](./dict/index.md) | Directory Index | Dictionary sources for C/Migemo: build script, Perl conversion/optimization tools, static Japanese conversion tables, and a Chinese dictionary. |
+| [test/](./test/index.md) | Directory Index | CTest test suite (test1) for the cmigemo migemo library, with C sources, CMake build rules, and a static dictionary fixture. |
+| [bench/](./bench/index.md) | Directory Index | Benchmark and profiling tools for measuring migemo dictionary load and query performance. |
+| [tools/](./tools/index.md) | Directory Index | Console driver tools and their CMake build rules for the cmigemo project. |
+| [wasm/](./wasm/index.md) | Directory Index | WebAssembly port of cMigemo with its Emscripten build, JavaScript wrapper API, and browser demo. |
+| [include/](./include/) | Directory | Public C API header template (migemo.h.in) for the migemo library. |
+| [doc/](./doc/) | Directory | Japanese README and Doxygen configuration for API documentation generation. |
+| [misc/](./misc/) | Directory | Reference C# wrapper and vim plugin (not part of the build). |
+| [.github/](./.github/) | Directory | GitHub CI workflows and Dependabot configuration. |

--- a/src/index.md
+++ b/src/index.md
@@ -1,32 +1,32 @@
 ---
 type: Directory Index
 title: "src Index"
-description: "Source files for the cmigemo core shared library (migemo) and its CLI tool, plus auxiliary build/test tools."
+description: "C sources and headers for the migemo shared library core (dictionary tree, romaji, regexp, charset), with CMake build rules and Windows build support files."
 tags: [index]
 ---
 
 # Overview
 
-This directory contains the C sources, headers, and CMake build scripts for the `migemo` shared library and the `cmigemo` CLI executable, along with the `testdir` folder holding auxiliary tools (`romaji`, `qspeed`) that are built outside the core library.
+This directory holds the C implementation of the `migemo` shared library: the migemo tree (dictionary storage/query), romaji conversion, regular expression generation, character set/encoding handling, and supporting utilities (string buffer, word list, filename helpers), plus the CMake build script and Windows module-definition/resource files.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [migemo.c](./migemo.c) | Source | Core migemo public API implementation (library and dictionary loading). |
-| [migemo_struct.h](./migemo_struct.h) | Header | Internal struct definitions shared across the core library. |
-| [rxgen.c](./rxgen.c) | Source | Regular expression generator for matching input against the migemo dictionary. |
-| [rxgen.h](./rxgen.h) | Header | Public declarations of the regular expression generator. |
-| [romaji.c](./romaji.c) | Source | Romaji (romajikana) conversion support for input handling. |
+| [migemo.c](./migemo.c) | Source | Core implementation of the public migemo API (open/close/query and dictionary loading). |
+| [migemo_struct.h](./migemo_struct.h) | Header | Defines the internal `struct migemo` aggregating the mtree, romaji tables, and rxgen state. |
+| [mtree.c](./mtree.c) | Source | Migemo tree (mtree) operations for loading the dictionary and querying words. |
+| [mtree.h](./mtree.h) | Header | Public declarations of the migemo tree (mtree) operations. |
+| [romaji.c](./romaji.c) | Source | Romaji conversion support for input handling. |
 | [romaji.h](./romaji.h) | Header | Public declarations of the romaji conversion module. |
-| [charset.c](./charset.c) | Source | Character set and multi-byte encoding conversion helpers. |
+| [rxgen.c](./rxgen.c) | Source | Regular expression generator producing patterns for matching input against the dictionary. |
+| [rxgen.h](./rxgen.h) | Header | Public declarations of the regular expression generator. |
+| [charset.c](./charset.c) | Source | Character set and multi-byte encoding conversion helpers (CP932, EUC-JP, UTF-8). |
 | [charset.h](./charset.h) | Header | Public declarations of the character set conversion module. |
 | [strbuf.c](./strbuf.c) | Source | Dynamic string buffer implementation used throughout the library. |
 | [strbuf.h](./strbuf.h) | Header | Public declarations of the string buffer module. |
-| [trie.c](./trie.c) | Source | Trie data structure used for dictionary storage and lookup. |
-| [trie.h](./trie.h) | Header | Public declarations of the trie data structure. |
-| [mtree.c](./mtree.c) | Source | Migemo tree (mtree) operations for building and searching the trie. |
-| [mtree.h](./mtree.h) | Header | Public declarations of the migemo tree operations. |
+| [trie.c](./trie.c) | Source | Trie statistics printing used for diagnosing the dictionary tree structure. |
+| [trie.h](./trie.h) | Header | Public declarations of the trie statistics helpers. |
 | [wordlist.c](./wordlist.c) | Source | Word list handling for dictionary expansion. |
 | [wordlist.h](./wordlist.h) | Header | Public declarations of the word list module. |
 | [filename.c](./filename.c) | Source | Filename manipulation helpers for locating dictionaries. |
@@ -34,7 +34,7 @@ This directory contains the C sources, headers, and CMake build scripts for the 
 | [common.h](./common.h) | Header | Shared code (e.g., debugging facilities) injected into all .c files. |
 | [migemo.def](./migemo.def) | Build Support | MSVC module definition file controlling exported library symbols. |
 | [migemo.rc.in](./migemo.rc.in) | Build Support | CMake template generating the Windows resource file for the library. |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake build rules for the migemo library, cmigemo binary, and tools. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules building the migemo library, generating the public header, and configuring Windows resources. |
 
 # References
 - [Parent Directory](../index.md)

--- a/test/index.md
+++ b/test/index.md
@@ -1,23 +1,23 @@
 ---
 type: Directory Index
 title: "test Index"
-description: "CTest test suite (test1) with C test sources verifying the migemo library and its fixtures."
+description: "CTest test suite (test1) for the cmigemo migemo library, with C sources, CMake build rules, and a static dictionary fixture."
 tags: [index]
 ---
 
 # Overview
 
-This directory contains the executable-based test suite for the cmigemo library: a CMake target that builds the `test1` binary from multiple C test files, registered with CTest, and run against a static migemo-dict fixture.
+This directory contains the executable-based CTest suite for the cmigemo library. The `test1` binary is built from `main.c`, `test1.c`, and `test_rxgen.c`, verifies migemo query conversion and regular-expression generation behavior, and runs against the static `test1/migemo-dict` fixture.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that build the `test1` executable and register the CTest suite. |
-| [main.c](./main.c) | Source | Test runner entry point that invokes the individual test functions. |
-| [test1.c](./test1.c) | Source | Main library test that loads the dictionary fixture and checks migemo conversion. |
-| [test_rxgen.c](./test_rxgen.c) | Source | Test of the regular expression generator (rxgen) module. |
-| [test1/](./test1/) | Directory Index | Test fixture directory holding the static `migemo-dict` file used by the tests. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that build the `test1` executable, register the `test_migemo1` CTest, and define the `check` target. |
+| [main.c](./main.c) | Source | Test runner entry point that invokes the test1 and test_rxgen test functions. |
+| [test1.c](./test1.c) | Source | Main library test that loads the migemo-dict and roma2hira fixtures and checks migemo_query output. |
+| [test_rxgen.c](./test_rxgen.c) | Source | Tests the rxgen regular-expression generator escape-character behavior and the migemo_set_escape_chars API. |
+| [test1/](./test1/) | Directory | Test fixture directory holding the static `migemo-dict` wordlist file. |
 
 # References
 - [Parent Directory](../index.md)

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,21 +1,20 @@
 ---
 type: Directory Index
 title: "tools Index"
-description: "Command-line tools (cmigemo and romaji) that exercise the migemo library, built and installed by CMake."
+description: "Console driver tools and their CMake build rules for the cmigemo project."
 tags: [index]
 ---
 
 # Overview
-
-This directory contains the command-line driver programs of the project: the `cmigemo` migemo query driver and the `romaji` romaji-conversion console, along with the CMake rules that build and install them.
+This directory holds standalone console tools (the `cmigemo` query driver and the `romaji` romaji-conversion console) together with the CMake rules that build and install them.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | CMake rules that build the cmigemo and romaji executables, set dictionary paths, and install cmigemo. |
-| [cmigemo.c](./cmigemo.c) | Source | Main driver of the cmigemo executable that interactively queries the migemo library from standard input. |
-| [romaji.c](./romaji.c) | Source | Console tool that demonstrates romaji conversion through hira2kata, han2zen, and zen2han sub-dictionaries. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build Script | Defines CMake targets that build the `cmigemo` and `romaji` executables and install `cmigemo` into the binary directory. |
+| [cmigemo.c](./cmigemo.c) | Source | CLI driver that opens a migemo dictionary and runs interactive regex queries with vim/emacs regexp options. |
+| [romaji.c](./romaji.c) | Source | Romaji conversion console tool that interactively expands queries through romaji-to-hiragana, hiragana-to-katakana, and kana conversion tables. |
 
 # References
 - [Parent Directory](../index.md)

--- a/wasm/index.md
+++ b/wasm/index.md
@@ -1,25 +1,24 @@
 ---
 type: Directory Index
 title: "wasm Index"
-description: "WebAssembly build of the cmigemo library with emscripten wrappers and a browser test page."
+description: "WebAssembly port of cMigemo with its Emscripten build, JavaScript wrapper API, and browser demo."
 tags: [index]
 ---
 
 # Overview
-
-This directory contains a standalone CMake build that compiles the cmigemo library to WebAssembly, along with the emscripten-generated JS wrapper, browser-side JS entry points, and a small HTML test harness.
+This directory contains the WebAssembly port of cMigemo: a CMake build that compiles the core C sources into an Emscripten module, the JavaScript wrapper that loads and drives that module, and a browser demo for verifying the port.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [CMakeLists.txt](./CMakeLists.txt) | Build | Standalone CMake rules that build the migemo_wasm executable with Emscripten. |
-| [index.js](./index.js) | Source | Browser/Node entry point that loads and instantiates the migemo WebAssembly module. |
-| [library.js](./library.js) | Source | Emscripten library function definitions linked into the WASM module. |
-| [migemo_wasm.js](./migemo_wasm.js) | Build Output | Emscripten-generated JavaScript loader for the compiled WASM module. |
-| [migemo_wasm.wasm](./migemo_wasm.wasm) | Build Output | Compiled WebAssembly binary of the migemo library. |
-| [.gitignore](./.gitignore) | Configuration | Git exclusion rules keeping the generated WASM build artifacts out of version control. |
-| [test/](./test/) | Directory Index | Browser test harness (HTML page and JS) for the WASM build. |
+| [.gitignore](./.gitignore) | Config | Excludes the generated `migemo_wasm.js` and `migemo_wasm.wasm` build artifacts from version control. |
+| [CMakeLists.txt](./CMakeLists.txt) | Build Config | Builds the migemo C sources into the `migemo_wasm` Emscripten target and copies the generated `.js`/`.wasm` outputs into this directory. |
+| [index.js](./index.js) | JavaScript API | Locates and instantiates the `createMigemoModule` factory and exposes a promise-based wrapper (`init`, `query`, `isEnable`, `close`) over the WASM migemo functions. |
+| [library.js](./library.js) | Emscripten Library | Adds a `$allocate`/`$ALLOC_NORMAL` helper to the Emscripten runtime for copying byte buffers into WASM memory. |
+| [migemo_wasm.js](./migemo_wasm.js) | Generated Glue | Emscripten-generated ES module exporting the `createMigemoModule` factory that loads the compiled binary. |
+| [migemo_wasm.wasm](./migemo_wasm.wasm) | WebAssembly Binary | Compiled WASM binary of the migemo C library exporting `migemo_open`, `migemo_query`, `migemo_close`, and related functions. |
+| [test/](./test/index.md) | Directory | Browser demo (`index.html`) and `test.js` that exercise dictionary initialization and incremental romaji queries against the WASM module. |
 
 # References
 - [Parent Directory](../index.md)


### PR DESCRIPTION
## Overview
Refreshes all OKF (Open Knowledge Format) `index.md` files across the repository to reflect recent structural changes and new benchmark/build additions.

## Changes
- **Coverage**: Updated directory indexes for `bench/`, `dict/`, `src/`, `test/`, `tools/`, `wasm/`, and the repository root (`index.md`).
- **Precision**: Enhanced `description` fields and file entry explanations to better detail component roles (e.g., `profile_migemo_open`, CMake targets, WASM bindings, Perl optimization scripts).
- **Format Consistency**: 
  - Ensured relative links explicitly point to target `index.md` files (e.g., `[src/](./src/index.md)`).
  - Cleaned up non-standard characters and character-encoding artifacts in data table descriptions.
  - Standardized entry types (`Build Script`, `Benchmark`, `JavaScript API`, etc.) for consistency across subdirectories.