### PR TITLE
refactor(tools): simplify CLI logic, add error checks, and clean up profile code

### DIFF
--- a/tools/cmigemo.c
+++ b/tools/cmigemo.c
@@ -121,7 +121,6 @@ main(int argc, char **argv)
     char *subdict[MIGEMO_SUBDICT_MAX];
     int subdict_count = 0;
     migemo *mo;
-    FILE *fplog = stdout;
     char *word = NULL;
     char *prgname = argv[0];
 
@@ -152,25 +151,22 @@ main(int argc, char **argv)
             help(prgname);
     }
 
-#ifdef _PROFILE
-    fplog = fopen("exe.log", "wt");
-#endif
-
     // Search for dictionaries in the current directory and the parent directory
     if (!dict)
     {
         const char *found = NULL;
         mo = open_first_migemo(&found, default_dicts);
         if (!word && !mode_quiet)
-            fprintf(fplog, "migemo_open(\"%s\")=%p\n", found ? found : "(N/A)",
+            fprintf(stdout, "migemo_open(\"%s\")=%p\n", found ? found : "(N/A)",
                     mo);
     }
     else
     {
         mo = migemo_open(dict);
         if (!word && !mode_quiet)
-            fprintf(fplog, "migemo_open(\"%s\")=%p\n", dict, mo);
+            fprintf(stdout, "migemo_open(\"%s\")=%p\n", dict, mo);
     }
+
     // Load sub-dictionaries
     if (subdict_count > 0)
     {
@@ -184,7 +180,7 @@ main(int argc, char **argv)
                 continue;
             result = migemo_load(mo, MIGEMO_DICTID_MIGEMO, subdict[i]);
             if (!word && !mode_quiet)
-                fprintf(fplog, "migemo_load(%p, %d, \"%s\")=%d\n", mo,
+                fprintf(stdout, "migemo_load(%p, %d, \"%s\")=%d\n", mo,
                         MIGEMO_DICTID_MIGEMO, subdict[i], result);
         }
     }
@@ -209,14 +205,13 @@ main(int argc, char **argv)
             if (!mode_nonewline)
                 migemo_set_operator(mo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
         }
-#ifndef _PROFILE
         if (word)
         {
             unsigned char *ans;
 
             ans = migemo_query(mo, word);
             if (ans)
-                fprintf(fplog, mode_vim ? "%s" : "%s\n", ans);
+                fprintf(stdout, mode_vim ? "%s" : "%s\n", ans);
             migemo_release(mo, ans);
         }
         else
@@ -225,26 +220,8 @@ main(int argc, char **argv)
                 printf("clock()=%f\n", (float)clock() / CLOCKS_PER_SEC);
             query_loop(mo, mode_quiet);
         }
-#else
-        // For profiling
-        {
-            unsigned char *ans;
-
-            ans = migemo_query(mo, "a");
-            if (ans)
-                fprintf(fplog, "  [%s]\n", ans);
-            migemo_release(mo, ans);
-
-            ans = migemo_query(mo, "k");
-            if (ans)
-                fprintf(fplog, "  [%s]\n", ans);
-            migemo_release(mo, ans);
-        }
-#endif
         migemo_close(mo);
     }
 
-    if (fplog != stdout)
-        fclose(fplog);
     return 0;
 }

--- a/tools/cmigemo.c
+++ b/tools/cmigemo.c
@@ -24,10 +24,9 @@
 int
 query_loop(migemo *mo, int quiet)
 {
+    unsigned char buf[256];
     while (!feof(stdin))
     {
-        unsigned char buf[256], *ans;
-
         if (!quiet)
             printf("QUERY: ");
         // Changed from gets() to fgets()
@@ -37,11 +36,14 @@ query_loop(migemo *mo, int quiet)
                 printf("\n");
             break;
         }
-        // Replace newline with NULL character
-        if ((ans = strchr(buf, '\n')) != NULL)
-            *ans = '\0';
+        // Replace LF with '\0'. If no LF is present, set the end of the buffer
+        // to '\0' to ensure the string is null-terminated.
+        int i = 0;
+        while (i < sizeof(buf) - 1 && buf[i] != '\n' && buf[i] != '\0')
+            i++;
+        buf[i] = '\0';
 
-        ans = migemo_query(mo, buf);
+        unsigned char *ans = migemo_query(mo, buf);
         if (ans)
             printf(quiet ? "%s\n" : "PATTERN: %s\n", ans);
         fflush(stdout);
@@ -118,13 +120,12 @@ main(int argc, char **argv)
     int mode_nonewline = 0;
     int mode_quiet = 0;
     char *dict = NULL;
-    char *subdict[MIGEMO_SUBDICT_MAX];
+    char *subdict[MIGEMO_SUBDICT_MAX] = {0};
     int subdict_count = 0;
     migemo *mo;
     char *word = NULL;
     char *prgname = argv[0];
 
-    memset(subdict, 0, sizeof(subdict));
     while (*++argv)
     {
         if (0)
@@ -179,58 +180,52 @@ main(int argc, char **argv)
     // Load sub-dictionaries
     if (subdict_count > 0)
     {
-        int i;
-
-        for (i = 0; i < subdict_count; ++i)
+        for (int i = 0; i < subdict_count; ++i)
         {
-            int result;
-
             if (subdict[i] == NULL || subdict[i][0] == '\0')
                 continue;
-            result = migemo_load(mo, MIGEMO_DICTID_MIGEMO, subdict[i]);
+            int result = migemo_load(mo, MIGEMO_DICTID_MIGEMO, subdict[i]);
             if (!word && !mode_quiet)
                 printf("migemo_load(%p, %d, \"%s\")=%d\n", mo,
                         MIGEMO_DICTID_MIGEMO, subdict[i], result);
         }
     }
 
-    if (!mo)
-        return 1;
+    // Configure operators for each editor.
+    if (mode_vim)
+    {
+        migemo_set_operator(mo, MIGEMO_OPINDEX_OR, "\\|");
+        migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_IN, "\\%(");
+        migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
+        if (!mode_nonewline)
+            migemo_set_operator(mo, MIGEMO_OPINDEX_NEWLINE, "\\_s*");
+    }
+    else if (mode_emacs)
+    {
+        migemo_set_operator(mo, MIGEMO_OPINDEX_OR, "\\|");
+        migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_IN, "\\(");
+        migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
+        if (!mode_nonewline)
+            migemo_set_operator(mo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
+    }
+
+    if (word)
+    {
+        unsigned char *ans;
+
+        ans = migemo_query(mo, word);
+        if (ans)
+            printf(mode_vim ? "%s" : "%s\n", ans);
+        migemo_release(mo, ans);
+    }
     else
     {
-        if (mode_vim)
-        {
-            migemo_set_operator(mo, MIGEMO_OPINDEX_OR, "\\|");
-            migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_IN, "\\%(");
-            migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
-            if (!mode_nonewline)
-                migemo_set_operator(mo, MIGEMO_OPINDEX_NEWLINE, "\\_s*");
-        }
-        else if (mode_emacs)
-        {
-            migemo_set_operator(mo, MIGEMO_OPINDEX_OR, "\\|");
-            migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_IN, "\\(");
-            migemo_set_operator(mo, MIGEMO_OPINDEX_NEST_OUT, "\\)");
-            if (!mode_nonewline)
-                migemo_set_operator(mo, MIGEMO_OPINDEX_NEWLINE, "\\s-*");
-        }
-        if (word)
-        {
-            unsigned char *ans;
-
-            ans = migemo_query(mo, word);
-            if (ans)
-                printf(mode_vim ? "%s" : "%s\n", ans);
-            migemo_release(mo, ans);
-        }
-        else
-        {
-            if (!mode_quiet)
-                printf("clock()=%f\n", (float)clock() / CLOCKS_PER_SEC);
-            query_loop(mo, mode_quiet);
-        }
-        migemo_close(mo);
+        if (!mode_quiet)
+            printf("clock()=%f\n", (float)clock() / CLOCKS_PER_SEC);
+        query_loop(mo, mode_quiet);
     }
+
+    migemo_close(mo);
 
     return 0;
 }

--- a/tools/cmigemo.c
+++ b/tools/cmigemo.c
@@ -157,14 +157,23 @@ main(int argc, char **argv)
         const char *found = NULL;
         mo = open_first_migemo(&found, default_dicts);
         if (!word && !mode_quiet)
-            fprintf(stdout, "migemo_open(\"%s\")=%p\n", found ? found : "(N/A)",
-                    mo);
+            printf("migemo_open(\"%s\")=%p\n", found ? found : "(N/A)", mo);
+        if (!mo)
+        {
+            printf("failed to load default dictionaries\n");
+            return 1;
+        }
     }
     else
     {
         mo = migemo_open(dict);
         if (!word && !mode_quiet)
-            fprintf(stdout, "migemo_open(\"%s\")=%p\n", dict, mo);
+            printf("migemo_open(\"%s\")=%p\n", dict, mo);
+        if (!mo)
+        {
+            printf("failed to load dictionary: %s\n", dict);
+            return 1;
+        }
     }
 
     // Load sub-dictionaries
@@ -180,7 +189,7 @@ main(int argc, char **argv)
                 continue;
             result = migemo_load(mo, MIGEMO_DICTID_MIGEMO, subdict[i]);
             if (!word && !mode_quiet)
-                fprintf(stdout, "migemo_load(%p, %d, \"%s\")=%d\n", mo,
+                printf("migemo_load(%p, %d, \"%s\")=%d\n", mo,
                         MIGEMO_DICTID_MIGEMO, subdict[i], result);
         }
     }
@@ -211,7 +220,7 @@ main(int argc, char **argv)
 
             ans = migemo_query(mo, word);
             if (ans)
-                fprintf(stdout, mode_vim ? "%s" : "%s\n", ans);
+                printf(mode_vim ? "%s" : "%s\n", ans);
             migemo_release(mo, ans);
         }
         else

--- a/tools/romaji.c
+++ b/tools/romaji.c
@@ -5,9 +5,12 @@
 // Author:  MURAOKA Taro <koron.kaoriya@gmail.com>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "romaji.h"
+
+#define ABOUT "romaji - Romaji converter"
 
 #ifndef DICTDIR
 # define DICTDIR "../../dict"
@@ -55,9 +58,8 @@ query_one(romaji *rj, romaji *hira2kata, romaji *han2zen, romaji *zen2han,
 void
 query_loop(romaji *rj, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
 {
-    char buf[256], *ans;
-
-    while (1)
+    unsigned char buf[256];
+    while (!feof(stdin))
     {
         printf("QUERY: ");
         if (!fgets(buf, sizeof(buf), stdin))
@@ -65,23 +67,49 @@ query_loop(romaji *rj, romaji *hira2kata, romaji *han2zen, romaji *zen2han)
             printf("\n");
             break;
         }
-        // Replace newline with NUL character
-        if ((ans = strchr(buf, '\n')) != NULL)
-            *ans = '\0';
+        // Replace LF with '\0'. If no LF is present, set the end of the buffer
+        // to '\0' to ensure the string is null-terminated.
+        int i = 0;
+        while (i < sizeof(buf) - 1 && buf[i] != '\n' && buf[i] != '\0')
+            i++;
+        buf[i] = '\0';
+
         query_one(rj, hira2kata, han2zen, zen2han, buf);
     }
+}
+
+static void
+help(char *prgname)
+{
+    printf("\
+%s \n\
+\n\
+USAGE: %s [OPTIONS]\n\
+\n\
+OPTIONS:\n\
+  -w --word <word>      Expand a <word> and soon exit.\n\
+  -h --help             Show this message.\n\
+",
+            ABOUT, prgname);
+    exit(0);
 }
 
 int
 main(int argc, char **argv)
 {
-    romaji *rj, *hira2kata, *han2zen, *zen2han;
     char *word = NULL;
+    char *prgname = argv[0];
 
-    rj = romaji_open();
-    hira2kata = romaji_open();
-    han2zen = romaji_open();
-    zen2han = romaji_open();
+    romaji *rj = romaji_open();
+    romaji *hira2kata = romaji_open();
+    romaji *han2zen = romaji_open();
+    romaji *zen2han = romaji_open();
+
+    if (!rj || !hira2kata || !han2zen || !zen2han)
+    {
+        printf("failed to allocate memory for romaji\n");
+        return 1;
+    }
 
     while (*++argv)
     {
@@ -89,26 +117,28 @@ main(int argc, char **argv)
             ;
         else if (argv[1] && (!strcmp("--word", *argv) || !strcmp("-w", *argv)))
             word = *++argv;
+        else if (!strcmp("--help", *argv) || !strcmp("-h", *argv))
+            help(prgname);
     }
 
-    if (rj && hira2kata && han2zen && zen2han)
-    {
-        int retval = 0;
+    // Load romaji dictionaries.
+    int retval = 0;
+    retval = romaji_load(rj, DICT_ROMA2HIRA, charset_utf8_char2int);
+    printf("romaji_load(%s)=%d\n", DICT_ROMA2HIRA, retval);
+    retval = romaji_load(hira2kata, DICT_HIRA2KATA, charset_utf8_char2int);
+    printf("romaji_load(%s)=%d\n", DICT_HIRA2KATA, retval);
+    retval = romaji_load(han2zen, DICT_HAN2ZEN, charset_utf8_char2int);
+    printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
+    retval = romaji_load(zen2han, DICT_ZEN2HAN, charset_utf8_char2int);
+    printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
 
-        retval = romaji_load(rj, DICT_ROMA2HIRA, charset_utf8_char2int);
-        printf("romaji_load(%s)=%d\n", DICT_ROMA2HIRA, retval);
-        retval = romaji_load(hira2kata, DICT_HIRA2KATA, charset_utf8_char2int);
-        printf("romaji_load(%s)=%d\n", DICT_HIRA2KATA, retval);
-        retval = romaji_load(han2zen, DICT_HAN2ZEN, charset_utf8_char2int);
-        printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
-        retval = romaji_load(zen2han, DICT_ZEN2HAN, charset_utf8_char2int);
-        printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
-        if (word)
-            query_one(rj, hira2kata, han2zen, zen2han, word);
-        else
-            query_loop(rj, hira2kata, han2zen, zen2han);
-    }
+    if (word)
+        query_one(rj, hira2kata, han2zen, zen2han, word);
+    else
+        query_loop(rj, hira2kata, han2zen, zen2han);
 
+    if (zen2han)
+        romaji_close(zen2han);
     if (han2zen)
         romaji_close(han2zen);
     if (hira2kata)

--- a/tools/romaji.c
+++ b/tools/romaji.c
@@ -130,7 +130,7 @@ main(int argc, char **argv)
     retval = romaji_load(han2zen, DICT_HAN2ZEN, charset_utf8_char2int);
     printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
     retval = romaji_load(zen2han, DICT_ZEN2HAN, charset_utf8_char2int);
-    printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
+    printf("romaji_load(%s)=%d\n", DICT_ZEN2HAN, retval);
 
     if (word)
         query_one(rj, hira2kata, han2zen, zen2han, word);


### PR DESCRIPTION
### Summary
Refactors and modernizes the command-line tools (`cmigemo` and `romaji`) to improve code cleanliness, consistency, and error handling.

### Key Changes
- **cmigemo**:
  - Removed legacy `_PROFILE` conditional compilation blocks and unnecessary log file (`fplog`) handling; all outputs now consistently use `stdout` / `printf`.
  - Added explicit `NULL` checks and error messages upon main dictionary loading failures.
  - Simplified control flow by removing redundant `else` blocks and nested logic.
  - Improved buffer null-termination handling in `query_loop()` to prevent potential string overflows.
- **romaji**:
  - Added `-h` / `--help` CLI option with usage details and `ABOUT` banner.
  - Added `NULL` memory checks after `romaji_open()` calls to guard against allocation failures.
  - Aligned input buffer string handling and code formatting with `cmigemo`.
  - Fixed a typo in the `romaji_load()` log output where `DICT_HAN2ZEN` was incorrectly printed for `zen2han`.