### PR TITLE
perf(bench): use high-resolution timing utilities for benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ profile:
 	cmake --build build --parallel --target profile
 
 format:
-	find src test include -type f \( -name "*.c" -o -name "*.h" \) | xargs clang-format -i
+	find src test include bench -type f \( -name "*.c" -o -name "*.h" \) | xargs clang-format -i
 
 format-cmake:
 	cmakefmt --in-place .

--- a/bench/bench_common.h
+++ b/bench/bench_common.h
@@ -1,0 +1,60 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+//
+// bench_common.h -
+//
+
+#pragma once
+
+#include <stdint.h>
+#include <time.h>
+
+typedef uint64_t bench_time_t;
+
+#if defined(_MSC_VER)
+# include <windows.h>
+
+static inline bench_time_t
+time_now(void)
+{
+    LARGE_INTEGER count;
+    QueryPerformanceCounter(&count);
+    return (bench_time_t)count.QuadPart;
+}
+
+static inline double
+time_to_sec(bench_time_t duration)
+{
+    LARGE_INTEGER freq;
+    QueryPerformanceFrequency(&freq);
+    return (double)duration / (double)freq.QuadPart;
+}
+
+#else
+
+static inline bench_time_t
+time_now(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (bench_time_t)((uint64_t)ts.tv_sec * 1000000000ULL
+                          + (uint64_t)ts.tv_nsec);
+}
+
+static inline double
+time_to_sec(bench_time_t duration)
+{
+    return (double)duration / 1e9;
+}
+
+#endif
+
+static inline bench_time_t
+time_since(bench_time_t start)
+{
+    return time_now() - start;
+}
+
+#define TIME_MEASURE_ADD(dur)                                                  \
+    for (bench_time_t _start = 0, _done = 0;                                   \
+            !_done && (_start = time_now(), 1);                                \
+            (dur) += time_since(_start), _done = 1)

--- a/bench/char_query.c
+++ b/bench/char_query.c
@@ -9,8 +9,8 @@
 #define NUM_TRIAL 50
 
 #include <stdio.h>
-#include <time.h>
 
+#include "bench_common.h"
 #include "migemo.h"
 #include "migemo_struct.h"
 
@@ -18,26 +18,22 @@
 # define DICTDIR "../../dict"
 #endif
 
-#define CLOCK2SEC(t) ((double)(t) / (double)CLOCKS_PER_SEC)
-
-static clock_t
+static bench_time_t
 profile_char_query(migemo *mo, int trial)
 {
     char key[2] = {'\0', '\0'};
-    clock_t dur = 0;
+    bench_time_t dur = 0;
+
     for (int i = 0; i < trial; ++i)
     {
-        printf("[%d] Progress... ", i);
         for (key[0] = 'a'; key[0] <= 'z'; ++key[0])
         {
-            printf("%s", key);
-            fflush(stdout);
-            clock_t start = clock();
-            char *ans = migemo_query(mo, key);
-            migemo_release(mo, ans);
-            dur += clock() - start;
+            TIME_MEASURE_ADD(dur)
+            {
+                char *ans = migemo_query(mo, key);
+                migemo_release(mo, ans);
+            }
         }
-        printf("\n");
     }
     return dur;
 }
@@ -46,22 +42,24 @@ int
 main(int argc, char **argv)
 {
     migemo *mo;
-    clock_t clock_load = 0, clock_query = 0, clock_tmp = 0;
+    bench_time_t dur_load = 0, dur_query = 0;
 
     printf("Loading\n");
-    clock_tmp = clock();
-    mo = migemo_open(DICTDIR "/" MIGEMO_DICT_FILENAME);
-    clock_load = clock() - clock_tmp;
+    TIME_MEASURE_ADD(dur_load)
+    {
+        mo = migemo_open(DICTDIR "/" MIGEMO_DICT_FILENAME);
+    }
     mtree_print_stat(mo->mtree, "mtree statistics");
+
     if (mo != NULL)
     {
         printf("Quering\n");
-        clock_query = profile_char_query(mo, NUM_TRIAL);
+        dur_query = profile_char_query(mo, NUM_TRIAL);
         migemo_close(mo);
     }
     printf("\n");
     printf("Results:\n");
-    printf("  load: %.3f secs\n", CLOCK2SEC(clock_load));
-    printf("  query: %.3f secs\n", CLOCK2SEC(clock_query));
+    printf("  load: %.9f secs\n", time_to_sec(dur_load));
+    printf("  query: %.9f secs\n", time_to_sec(dur_query));
     return 0;
 }

--- a/bench/migemo_open.c
+++ b/bench/migemo_open.c
@@ -7,8 +7,8 @@
 #define NUM_TRIAL 25
 
 #include <stdio.h>
-#include <time.h>
 
+#include "bench_common.h"
 #include "migemo.h"
 
 #ifndef DICTDIR
@@ -22,19 +22,17 @@ main(int argc, char **argv)
 {
     int trial = NUM_TRIAL;
     migemo *mo;
-    clock_t sum_open = 0, sum_close = 0;
+    bench_time_t sum_open = 0, sum_close = 0;
     for (int i = 0; i < trial; i++)
     {
-        clock_t t0 = clock();
-        mo = migemo_open(DICTDIR "/" MIGEMO_DICT_FILENAME);
-        clock_t t1 = clock();
-        migemo_close(mo);
-        clock_t t2 = clock();
-        sum_open += t1 - t0;
-        sum_close += t2 - t1;
+        TIME_MEASURE_ADD(sum_open)
+        {
+            mo = migemo_open(DICTDIR "/" MIGEMO_DICT_FILENAME);
+        }
+        TIME_MEASURE_ADD(sum_close) { migemo_close(mo); }
     }
     printf("Results:\n");
-    printf("  migemo_open:  %.3f secs\n", CLOCK2SEC(sum_open));
-    printf("  migemo_close: %.3f secs\n", CLOCK2SEC(sum_close));
+    printf("  migemo_open:  %.3f secs\n", time_to_sec(sum_open));
+    printf("  migemo_close: %.3f secs\n", time_to_sec(sum_close));
     return 0;
 }


### PR DESCRIPTION
## Summary

Replaces standard `clock()` calls in benchmark programs with high-resolution, cross-platform monotonic time measurement utilities.

## Changes

- **Introduced `bench_common.h`**:
  - Implemented `bench_time_t` for raw count accumulation to avoid precision loss / float rounding issues during measurement iterations.
  - Added POSIX support via `clock_gettime(CLOCK_MONOTONIC, ...)` and MSVC support via `QueryPerformanceCounter`.
  - Added `TIME_MEASURE_ADD` scoping macro for streamlined benchmarking without verbose timing boilerplate.
- **Updated Benchmarks**:
  - Refactored `bench/char_query.c` and `bench/migemo_open.c` to use `TIME_MEASURE_ADD` and `time_to_sec()`.
- **Formatting**:
  - Updated `Makefile` to include the `bench` directory in `clang-format` targets.