### PR TITLE
ci: separate dictionary files in WebAssembly release package

### DIFF
--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build
       run: |
-        emcmake cmake -B build-wasm -DBUILD_DICT=OFF -DCMAKE_BUILD_TYPE=Release
+        emcmake cmake -B build-wasm -DBUILD_DICT=ON -DCMAKE_BUILD_TYPE=Release
         cmake --build build-wasm
 
     - name: Test
@@ -38,12 +38,18 @@ jobs:
         PRERELEASE=$(grep -w MIGEMO_VERSION_PRERELEASE build-wasm/src/include/migemo.h | cut -d '"' -f 2)
         FULL_VER="${VERSION}${PRERELEASE}"
 
-        PKG_NAME="cmigemo-${FULL_VER}-wasm"
-        PKG_DIR="build-wasm/${PKG_NAME}"
-        mkdir -p "$PKG_DIR"
-        cp build-wasm/bin/migemo_wasm.* "$PKG_DIR"
-        cp wasm/index.js wasm/library.js "$PKG_DIR"
-        ( cd build-wasm && zip -r "${PKG_NAME}.zip" "$PKG_NAME" )
+        WASM_PKG_NAME="cmigemo-${FULL_VER}-wasm"
+        WASM_PKG_DIR="build-wasm/${WASM_PKG_NAME}"
+        mkdir -p "$WASM_PKG_DIR"
+        cp build-wasm/bin/migemo_wasm.* "$WASM_PKG_DIR"
+        cp wasm/index.js wasm/library.js "$WASM_PKG_DIR"
+        ( cd build-wasm && zip -r "${WASM_PKG_NAME}.zip" "$WASM_PKG_NAME" )
+
+        DICT_PKG_NAME="cmigemo-${FULL_VER}-dict"
+        DICT_PKG_DIR="build-wasm/${DICT_PKG_NAME}"
+        mkdir -p "$DICT_PKG_DIR/dict"
+        cp -r build-wasm/dict/utf-8 build-wasm/dict/euc-jp build-wasm/dict/cp932 "$DICT_PKG_DIR/dict/"
+        ( cd build-wasm && zip -r "${DICT_PKG_NAME}.zip" "$DICT_PKG_NAME" )
 
     - name: List files in build
       run: tree -Fh build-wasm


### PR DESCRIPTION
Separated dictionary files into a dedicated zip package in the WebAssembly CI workflow (`ci-wasm.yml`). Enables dictionary building (`BUILD_DICT=ON`) and creates both `cmigemo-${FULL_VER}-wasm.zip` and `cmigemo-${FULL_VER}-dict.zip`.

---
*PR created automatically by Jules for task [6818516104523409226](https://jules.google.com/task/6818516104523409226) started by @koron*