### PR TITLE
build(wasm): enable dictionary build and include UTF-8 dict with demo page

### DIFF
--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build
       run: |
-        emcmake cmake -B build-wasm -DBUILD_DICT=OFF -DCMAKE_BUILD_TYPE=Release
+        emcmake cmake -B build-wasm -DBUILD_DICT=ON -DCMAKE_BUILD_TYPE=Release
         cmake --build build-wasm
 
     - name: Test
@@ -43,6 +43,8 @@ jobs:
         mkdir -p "$PKG_DIR"
         cp build-wasm/bin/migemo_wasm.* "$PKG_DIR"
         cp wasm/index.js wasm/library.js "$PKG_DIR"
+        mkdir -p "$PKG_DIR/dict"
+        cp -r build-wasm/dict/utf-8/* "$PKG_DIR/dict/"
         ( cd build-wasm && zip -r "${PKG_NAME}.zip" "$PKG_NAME" )
 
     - name: List files in build

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -44,7 +44,7 @@ jobs:
         cp build-wasm/bin/migemo_wasm.* "$PKG_DIR"
         cp wasm/index.js wasm/library.js wasm/demo.html "$PKG_DIR"
         mkdir -p "$PKG_DIR/dict"
-        cp -r build-wasm/dict/utf-8/* "$PKG_DIR/dict/"
+        cp -r build-wasm/dict/utf-8/. "$PKG_DIR/dict/"
         ( cd build-wasm && zip -r "${PKG_NAME}.zip" "$PKG_NAME" )
 
     - name: List files in build

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -42,7 +42,7 @@ jobs:
         PKG_DIR="build-wasm/${PKG_NAME}"
         mkdir -p "$PKG_DIR"
         cp build-wasm/bin/migemo_wasm.* "$PKG_DIR"
-        cp wasm/index.js wasm/library.js "$PKG_DIR"
+        cp wasm/index.js wasm/library.js wasm/demo.html "$PKG_DIR"
         mkdir -p "$PKG_DIR/dict"
         cp -r build-wasm/dict/utf-8/* "$PKG_DIR/dict/"
         ( cd build-wasm && zip -r "${PKG_NAME}.zip" "$PKG_NAME" )

--- a/wasm/.gitignore
+++ b/wasm/.gitignore
@@ -1,2 +1,3 @@
 migemo_wasm.js
 migemo_wasm.wasm
+dict/

--- a/wasm/demo.html
+++ b/wasm/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<h1>C/Migemo WASM</h1>
+
+<blockquote style="background: #f8f9fa; border-left: 4px solid #0366d6; padding: 8px 12px; margin: 10px 0;">
+  <strong>Notice:</strong> Load this page via an HTTP server (e.g., <code>npx serve .</code>, or <code>python -m http.server</code>). Fetching dictionary files directly via <code>file://</code> protocol will fail due to browser security restrictions.
+</blockquote>
+
+<ol>
+  <li>Open developer's console (<key>Ctrl</key> + <key>Shift</key> + <key>j</key>)</li>
+  <li>Run <code>migemo.version()</code>, then you'll get version of C/Migemo</li>
+  <li>
+    Run <code>migemo.query('akas')</code>, then you'll get a RegExp object:<br>
+    <code>/([暴灯証證]|akas|あか[さしすせそっ]|アカ[サシスセソッ]|垢擦り|明[石科]|絳し|赤([司坂崎潮白碕線芝錆]|っ恥|信号|新聞|水晶|瀬川)|ａｋａｓ|ｱｶ[ｯｻｼｽｾｿ])/</code>
+  </li>
+  <li>
+    Run <code>migemo.query('asak')</code>, then you'll get a RegExp object:<br>
+    <code>/(asak|あさ[かきくけこっ子]|アサ[カキクケコッ]|亜抄子|安(積|佐北)|明後日|朝([倉加子川影明霞風]|っ(腹|ぱら)|香宮)|浅[倉口子川草香]|麻[倉子木]|ａｓａｋ|ｱｻ[ｯｶｷｸｹｺ])/</code>
+  </li>
+</ol>
+
+<script type="module">
+
+import migemo from './index.js';
+
+const dictroot = './dict';
+
+const [mainDict, roma2hira, hira2kata, han2zen, zen2han] = await Promise.all([
+  fetch(`${dictroot}/migemo-dict`).then(r => r.arrayBuffer()),
+  fetch(`${dictroot}/roma2hira.dat`).then(r => r.arrayBuffer()),
+  fetch(`${dictroot}/hira2kata.dat`).then(r => r.arrayBuffer()),
+  fetch(`${dictroot}/han2zen.dat`).then(r => r.arrayBuffer()),
+  fetch(`${dictroot}/zen2han.dat`).then(r => r.arrayBuffer()),
+]);
+
+await migemo.init({
+  dictData: mainDict,
+  subdicts: {
+    roma2hira,
+    hira2kata,
+    han2zen,
+    zen2han,
+  },
+});
+
+window.migemo = migemo;
+
+</script>
+</body>
+</html>

--- a/wasm/index.md
+++ b/wasm/index.md
@@ -1,24 +1,26 @@
 ---
 type: Directory Index
 title: "wasm Index"
-description: "WebAssembly port of cMigemo with its Emscripten build, JavaScript wrapper API, and browser demo."
+description: "Emscripten WebAssembly build of C/Migemo exposing a browser/Node JavaScript API for dictionary queries, with a demo page, runtime dictionaries, and tests."
 tags: [index]
 ---
 
 # Overview
-This directory contains the WebAssembly port of cMigemo: a CMake build that compiles the core C sources into an Emscripten module, the JavaScript wrapper that loads and drives that module, and a browser demo for verifying the port.
+This directory compiles the C/Migemo engine to WebAssembly via CMake/Emscripten, producing a modular ES module (`createMigemoModule`) plus an `index.js` API wrapper that lets web pages and Node load a dictionary and build query regular expressions.
 
 # Directory Contents
 
 | File / Path | Type | Description |
 | :--- | :--- | :--- |
-| [.gitignore](./.gitignore) | Config | Excludes the generated `migemo_wasm.js` and `migemo_wasm.wasm` build artifacts from version control. |
-| [CMakeLists.txt](./CMakeLists.txt) | Build Config | Builds the migemo C sources into the `migemo_wasm` Emscripten target and copies the generated `.js`/`.wasm` outputs into this directory. |
-| [index.js](./index.js) | JavaScript API | Locates and instantiates the `createMigemoModule` factory and exposes a promise-based wrapper (`init`, `query`, `isEnable`, `close`) over the WASM migemo functions. |
-| [library.js](./library.js) | Emscripten Library | Adds a `$allocate`/`$ALLOC_NORMAL` helper to the Emscripten runtime for copying byte buffers into WASM memory. |
-| [migemo_wasm.js](./migemo_wasm.js) | Generated Glue | Emscripten-generated ES module exporting the `createMigemoModule` factory that loads the compiled binary. |
-| [migemo_wasm.wasm](./migemo_wasm.wasm) | WebAssembly Binary | Compiled WASM binary of the migemo C library exporting `migemo_open`, `migemo_query`, `migemo_close`, and related functions. |
-| [test/](./test/index.md) | Directory | Browser demo (`index.html`) and `test.js` that exercise dictionary initialization and incremental romaji queries against the WASM module. |
+| [.gitignore](./.gitignore) | Text | Ignores the generated `migemo_wasm.js`/`migemo_wasm.wasm` artifacts and the checked-out `dict/` directory. |
+| [CMakeLists.txt](./CMakeLists.txt) | CMake | Compiles the migemo C sources into the `migemo_wasm` Emscripten target exporting `createMigemoModule` and copies the generated JS/WASM into this directory. |
+| [demo.html](./demo.html) | HTML | Browser demo that loads the module, fetches the dictionaries from `./dict`, and exposes `window.migemo` for console use. |
+| [index.js](./index.js) | JavaScript | Public JS wrapper that locates the WASM module, normalizes dictionary options, and exposes `init`, `query`, `version` and lifecycle methods. |
+| [library.js](./library.js) | JavaScript | Emscripten JS library snippet adding `allocate`/`ALLOC_NORMAL` helpers for passing dictionary buffers into the module. |
+| [migemo_wasm.js](./migemo_wasm.js) | Generated | Emscripten-generated ES module loader (web+node) that instantiates the WASM binary. |
+| [migemo_wasm.wasm](./migemo_wasm.wasm) | WebAssembly | Emscripten-generated WebAssembly binary containing the migemo query engine. |
+| [dict/](./dict/) | Directory | Runtime dictionary files: main `migemo-dict` and `migemo-dict-zh` plus the `roma2hira`, `hira2kata`, `han2zen`, `zen2han` sub-dictionaries, served over HTTP at runtime. |
+| [test/](./test/) | Directory | Test harness (`index.html` + `test.js`) for the WASM module. |
 
 # References
 - [Parent Directory](../index.md)


### PR DESCRIPTION
## Summary
Enables dictionary generation for the WebAssembly target and includes the built UTF-8 dictionary files along with an HTML demo page in the release artifact package.

## Changes
- **CI Configuration (`.github/workflows/ci-wasm.yml`)**:
  - Changed CMake build option `-DBUILD_DICT=OFF` to `-DBUILD_DICT=ON`.
  - Added step to copy compiled UTF-8 dictionary files into `$PKG_DIR/dict/`.
  - Updated artifact copy command to include `wasm/demo.html`.
- **Demo Page (`wasm/demo.html`)**:
  - Added a standalone HTML page demonstrating how to load and initialize `migemo` using local WebAssembly binaries and UTF-8 dictionary files via ES modules.
- **Documentation & Ignore (`wasm/index.md`, `wasm/.gitignore`)**:
  - Updated directory documentation to reflect the inclusion of demo assets and dictionary files.
  - Added `dict/` to `.gitignore`.