### PR TITLE
test(romaji): add unit tests, fix CP932 handling, and refactor Makefile tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@
 
 .PHONY: build test profile tags format format-cmake package clean distclean
 
-TEST_TARGETS = src/*.c src/*.h test/*.c bench/*.c bench/*.h
+TAGS_TARGETS = src/*.c src/*.h test/*.c test/*.h bench/*.c bench/*.h
 
 build:
 	cmake -B build
 	cmake --build build --parallel
 
-tags: $(TEST_TARGETS)
-	ctags $(TEST_TARGETS) --langmap=c:+.in include/migemo.h.in
+tags: $(TAGS_TARGETS)
+	ctags $(TAGS_TARGETS) --langmap=c:+.in include/migemo.h.in
 
 test:
 	cmake -B build

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,14 @@
 
 .PHONY: build test profile tags format format-cmake package clean distclean
 
+TEST_TARGETS = src/*.c src/*.h test/*.c bench/*.c bench/*.h
+
 build:
 	cmake -B build
 	cmake --build build --parallel
 
-tags: src/*.c src/*.h
-	ctags src/*.c src/*.h --langmap=c:+.in include/migemo.h.in
+tags: $(TEST_TARGETS)
+	ctags $(TEST_TARGETS) --langmap=c:+.in include/migemo.h.in
 
 test:
 	cmake -B build

--- a/src/wordlist.h
+++ b/src/wordlist.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct wordlist wordlist;
 struct wordlist

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test1 main.c test1.c test_rxgen.c)
+add_executable(test1 main.c test1.c test_romaji.c test_rxgen.c)
 
 target_link_libraries(test1 PRIVATE migemo_static)
 

--- a/test/main.c
+++ b/test/main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 int test1(void);
+int test_romaji(void);
 int test_rxgen(void);
 
 int
@@ -10,6 +11,8 @@ main(int argc, char **argv)
 {
     int r;
     if ((r = test1()) != 0)
+        return r;
+    if ((r = test_romaji()) != 0)
         return r;
     if ((r = test_rxgen()) != 0)
         return r;

--- a/test/test1.c
+++ b/test/test1.c
@@ -4,12 +4,10 @@
 #include <string.h>
 
 #include "migemo.h"
+#include "test_common.h"
 
 #ifndef TEST_DICTDIR_MIGEMO
 # define TEST_DICTDIR_MIGEMO "test1"
-#endif
-#ifndef TEST_DICTDIR_ROMA2HIRA
-# define TEST_DICTDIR_ROMA2HIRA "../dict"
 #endif
 
 static int

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -1,0 +1,7 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+
+#pragma once
+
+#ifndef TEST_DICTDIR_ROMA2HIRA
+# define TEST_DICTDIR_ROMA2HIRA "../dict"
+#endif

--- a/test/test_romaji.c
+++ b/test/test_romaji.c
@@ -1,0 +1,108 @@
+// vim:set ts=8 sts=4 sw=4 tw=0 et:
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "romaji.h"
+#include "wordlist.h"
+
+#include "test_common.h"
+
+static uint32_t
+count_list(wordlist *list)
+{
+    uint32_t count = 0;
+    for (; list; list = list->next)
+        count++;
+    return count;
+}
+
+static int
+check_convert(romaji *rj, const unsigned char *src, const unsigned char **want)
+{
+    int result = 1;
+    wordlist *list = romaji_convert_all(rj, src);
+
+    uint32_t got_count = count_list(list);
+    uint32_t want_count = 0;
+    for (const unsigned char **p = want; *p; p++)
+        want_count++;
+
+    if (got_count != want_count)
+    {
+        printf("count mismatch: want=%d got=%d src=%s\n", want_count, got_count,
+                src);
+        goto END;
+    }
+    if (got_count == 0)
+    {
+        result = 0;
+        goto END;
+    }
+
+    wordlist *wl = list;
+    for (uint32_t i = 0; i < got_count; i++)
+    {
+        if (strcmp(want[i], wl->ptr))
+        {
+            printf("#%d mismatch: want=%s got=%s src=%s\n", i, want[i], wl->ptr,
+                    src);
+            goto END;
+        }
+        wl = wl->next;
+    }
+
+    result = 0;
+END:
+    if (list && result != 0)
+    {
+        printf("got list for src=%s\n", src);
+        int i = 0;
+        for (wordlist *curr = list; curr; curr = curr->next)
+            printf("  #%d %s\n", i++, curr->ptr);
+    }
+    if (list)
+        wordlist_destroy(list);
+    return result;
+}
+
+int
+test_romaji(void)
+{
+    romaji *rj = romaji_open();
+    int has_error = 1;
+    if (!rj)
+    {
+        printf("Failed: romaji_open() returned NULL\n");
+        goto END;
+    }
+
+    int r;
+    r = romaji_load(rj, TEST_DICTDIR_ROMA2HIRA "/roma2hira.dat", NULL);
+    if (r != 0)
+    {
+        printf("Failed: romaji_load() returned non zero: %d", r);
+        goto END;
+    }
+
+    r = check_convert(rj, "a", (const unsigned char *[]){"あ", NULL});
+    if (r != 0)
+        goto END;
+
+    r = check_convert(rj, "aki", (const unsigned char *[]){"あき", NULL});
+    if (r != 0)
+        goto END;
+
+    r = check_convert(rj, "k",
+            (const unsigned char *[]){"か", "け", "き", "っ", "こ", "く",
+                    "くぁ", "きゃ", "きぇ", "きぃ", "きょ", "きゅ", NULL});
+    if (r != 0)
+        goto END;
+
+    has_error = 0; // Passed all cases.
+END:
+    if (rj)
+        romaji_close(rj);
+    return has_error;
+}

--- a/test/test_romaji.c
+++ b/test/test_romaji.c
@@ -19,7 +19,7 @@ count_list(wordlist *list)
 }
 
 static int
-check_convert(romaji *rj, const unsigned char *src, const unsigned char **want)
+check_all(romaji *rj, const unsigned char *src, const unsigned char **want)
 {
     int result = 1;
     wordlist *list = romaji_convert_all(rj, src);
@@ -67,8 +67,14 @@ END:
     return result;
 }
 
-int
-test_romaji(void)
+static int
+check_one(romaji *rj, const unsigned char *src, const unsigned char *want)
+{
+    return check_all(rj, src, (const unsigned char *[]){ want, NULL });
+}
+
+static int
+test_roma2hira(void)
 {
     romaji *rj = romaji_open();
     int has_error = 1;
@@ -86,17 +92,33 @@ test_romaji(void)
         goto END;
     }
 
-    r = check_convert(rj, "a", (const unsigned char *[]){"あ", NULL});
+    r = check_all(rj, "a", (const unsigned char *[]){"あ", NULL});
     if (r != 0)
         goto END;
 
-    r = check_convert(rj, "aki", (const unsigned char *[]){"あき", NULL});
+    r = check_all(rj, "aki", (const unsigned char *[]){"あき", NULL});
     if (r != 0)
         goto END;
 
-    r = check_convert(rj, "k",
+    r = check_all(rj, "k",
             (const unsigned char *[]){"か", "け", "き", "っ", "こ", "く",
                     "くぁ", "きゃ", "きぇ", "きぃ", "きょ", "きゅ", NULL});
+    if (r != 0)
+        goto END;
+
+    r = check_all(rj, "nya", (const unsigned char *[]){"にゃ", NULL});
+    if (r != 0)
+        goto END;
+
+    r = check_all(rj, "ny",
+            (const unsigned char *[]){
+                    "にゃ", "にぇ", "にぃ", "にょ", "にゅ", NULL});
+    if (r != 0)
+        goto END;
+
+    r = check_all(rj, "n",
+            (const unsigned char *[]){"ん", "な", "ね", "に", "の", "ぬ",
+                    "にゃ", "にぇ", "にぃ", "にょ", "にゅ", NULL});
     if (r != 0)
         goto END;
 
@@ -105,4 +127,53 @@ END:
     if (rj)
         romaji_close(rj);
     return has_error;
+}
+
+static int
+test_hira2kana(void)
+{
+    romaji *rj = romaji_open();
+    int has_error = 1;
+    if (!rj)
+    {
+        printf("Failed: romaji_open() returned NULL\n");
+        goto END;
+    }
+
+    int r;
+    r = romaji_load(rj, TEST_DICTDIR_ROMA2HIRA "/hira2kata.dat", NULL);
+    if (r != 0)
+    {
+        printf("Failed: romaji_load() returned non zero: %d", r);
+        goto END;
+    }
+
+    r = check_one(rj, "あ", "ア");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "にゃ", "ニャ");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "きゃんでぃ", "キャンディ");
+    if (r != 0)
+        goto END;
+
+    has_error = 0; // Passed all cases.
+END:
+    if (rj)
+        romaji_close(rj);
+    return has_error;
+}
+
+int
+test_romaji(void)
+{
+    int r;
+    if ((r = test_roma2hira()) != 0)
+        return r;
+    if ((r = test_hira2kana()) != 0)
+        return r;
+    return 0;
 }

--- a/test/test_romaji.c
+++ b/test/test_romaji.c
@@ -122,6 +122,45 @@ test_roma2hira(void)
     if (r != 0)
         goto END;
 
+    r = check_all(rj, "", (const unsigned char *[]){ "", NULL });
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "nn", "ん");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "n'", "ん");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "ltu", "っ");
+    if (r != 0)
+        goto END;
+
+    r = check_all(rj, "nk",
+            (const unsigned char *[]){"んか", "んけ", "んき", "んっ", "んこ",
+                    "んく", "んくぁ", "んきゃ", "んきぇ", "んきぃ",
+                    "んきょ", "んきゅ", NULL});
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "nba", "んば");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "bba", "っば");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "ai", "あい");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "kate", "かて");
+    if (r != 0)
+        goto END;
+
     has_error = 0; // Passed all cases.
 END:
     if (rj)
@@ -157,6 +196,22 @@ test_hira2kana(void)
         goto END;
 
     r = check_one(rj, "きゃんでぃ", "キャンディ");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "っ", "ッ");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "しゃ", "シャ");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "きゃ", "キャ");
+    if (r != 0)
+        goto END;
+
+    r = check_one(rj, "きゃんでいー", "キャンデイー");
     if (r != 0)
         goto END;
 

--- a/tools/romaji.c
+++ b/tools/romaji.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "charset.h"
 #include "romaji.h"
 
 #define ABOUT "romaji - Romaji converter"
@@ -121,15 +122,20 @@ main(int argc, char **argv)
             help(prgname);
     }
 
+    CHARSET_PROC_CHAR2INT char2int = charset_utf8_char2int;
+    // Detect charset
+    if (strstr(DICT_ROMA2HIRA, "cp932"))
+        char2int = charset_cp932_char2int;
+
     // Load romaji dictionaries.
     int retval = 0;
-    retval = romaji_load(rj, DICT_ROMA2HIRA, charset_utf8_char2int);
+    retval = romaji_load(rj, DICT_ROMA2HIRA, char2int);
     printf("romaji_load(%s)=%d\n", DICT_ROMA2HIRA, retval);
-    retval = romaji_load(hira2kata, DICT_HIRA2KATA, charset_utf8_char2int);
+    retval = romaji_load(hira2kata, DICT_HIRA2KATA, char2int);
     printf("romaji_load(%s)=%d\n", DICT_HIRA2KATA, retval);
-    retval = romaji_load(han2zen, DICT_HAN2ZEN, charset_utf8_char2int);
+    retval = romaji_load(han2zen, DICT_HAN2ZEN, char2int);
     printf("romaji_load(%s)=%d\n", DICT_HAN2ZEN, retval);
-    retval = romaji_load(zen2han, DICT_ZEN2HAN, charset_utf8_char2int);
+    retval = romaji_load(zen2han, DICT_ZEN2HAN, char2int);
     printf("romaji_load(%s)=%d\n", DICT_ZEN2HAN, retval);
 
     if (word)


### PR DESCRIPTION
### Summary
- Added a comprehensive unit test suite (`test_romaji.c`) covering `roma2hira` and `hira2kata` conversions, including edge cases like sokuon (`っ`) and hatsuon (`ん`).
- Configured `CMakeLists.txt` and `main.c` to integrate `test_romaji` into the main test run.
- Updated `tools/romaji.c` to dynamically detect `cp932` dictionary paths and select `charset_cp932_char2int`.
- Refactored `Makefile` by introducing `TAGS_TARGETS` to include source, test, and bench files for ctags generation.

### Details
- **Unit Tests (`test_romaji.c`)**:
  - `test_roma2hira()`: Tests basic vowels, dynamic consonant expansions (`k`, `ny`, `n`), double consonants (`bba`), and special sequences (`nn`, `n'`, `ltu`).
  - `test_hira2kana()`: Validates hiragana to katakana mapping rules.
- **CP932 Support**:
  - Dynamically selects `charset_cp932_char2int` when `DICT_ROMA2HIRA` contains "cp932", resolving character encoding mismatches on startup.
- **Build Infrastructure**:
  - Defined `TAGS_TARGETS` in `Makefile` to expand ctags indexing across `src/`, `test/`, and `bench/`.