### PR TITLE
build(bench): improve profiling setup with isolated working directories and gmon handling

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         cmake --build build --target profile
         mkdir -p tmp/profile-linux-${{ matrix.arch }}
-        cp build/profile*.log tmp/profile-linux-${{ matrix.arch }}
+        cp build/bench/profile*.log tmp/profile-linux-${{ matrix.arch }}
 
     - name: Packaging
       run: |

--- a/.github/workflows/ci-windows-msys2.yml
+++ b/.github/workflows/ci-windows-msys2.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         cmake --build build --target profile
         mkdir -p tmp/profile-windows-msys-amd64
-        mv build/profile*.log tmp/profile-windows-msys-amd64
+        cp build/bench/profile*.log tmp/profile-windows-msys-amd64
 
     - name: Packaging
       shell: msys2 {0}

--- a/.github/workflows/ci-windows-ucrt64.yml
+++ b/.github/workflows/ci-windows-ucrt64.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         cmake --build build --target profile
         mkdir -p tmp/profile-windows-ucrt64-amd64
-        mv build/profile*.log tmp/profile-windows-ucrt64-amd64
+        cp build/bench/profile*.log tmp/profile-windows-ucrt64-amd64
 
     - name: Packaging
       shell: msys2 {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 
 project(
   cmigemo

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -37,6 +37,7 @@ function(add_profile_target target_name)
   add_custom_target(
     ${profile_target}
     COMMAND $<TARGET_FILE:${bench_target}>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_NAME:${bench_target}>.gmon" gmon.out
     COMMAND
       ${GPROF_EXECUTABLE} $<TARGET_FILE:${bench_target}> gmon.out >
       ${profile_target}.log

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -40,11 +40,15 @@ function(add_profile_target target_name)
   add_custom_target(
     ${profile_target}
     COMMAND $<TARGET_FILE:${bench_target}>
-    COMMAND ${CMAKE_COMMAND} -DSRC="$<TARGET_FILE_NAME:${bench_target}>.gmon" -DDST=gmon.out -P "${CMAKE_CURRENT_SOURCE_DIR}/copy_if_exists.cmake"
+    COMMAND
+      ${CMAKE_COMMAND} -DSRC="$<TARGET_FILE_NAME:${bench_target}>.gmon"
+      -DDST=gmon.out -P "${CMAKE_CURRENT_SOURCE_DIR}/copy_if_exists.cmake"
     COMMAND
       ${GPROF_EXECUTABLE} $<TARGET_FILE:${bench_target}> gmon.out >
       "${PROJECT_BINARY_DIR}/bench/${profile_target}.log"
-    COMMAND ${CMAKE_COMMAND} -E remove gmon.out "$<TARGET_FILE_NAME:${bench_target}>.gmon"
+    COMMAND
+      ${CMAKE_COMMAND} -E remove gmon.out
+      "$<TARGET_FILE_NAME:${bench_target}>.gmon"
     WORKING_DIRECTORY ${work_dir}
     DEPENDS ${bench_target}
     COMMENT "Profiling ${target_name} -> ${profile_target}.log")

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -34,15 +34,18 @@ function(add_profile_target target_name)
   add_executable(${bench_target} "${target_name}.c")
   target_link_libraries(${bench_target} PRIVATE migemo_profile)
 
+  set(work_dir "${PROJECT_BINARY_DIR}/bench/${target_name}")
+  file(MAKE_DIRECTORY "${work_dir}")
+
   add_custom_target(
     ${profile_target}
     COMMAND $<TARGET_FILE:${bench_target}>
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_NAME:${bench_target}>.gmon" gmon.out
+    COMMAND ${CMAKE_COMMAND} -DSRC="$<TARGET_FILE_NAME:${bench_target}>.gmon" -DDST=gmon.out -P "${CMAKE_CURRENT_SOURCE_DIR}/copy_if_exists.cmake"
     COMMAND
       ${GPROF_EXECUTABLE} $<TARGET_FILE:${bench_target}> gmon.out >
-      ${profile_target}.log
-    COMMAND ${CMAKE_COMMAND} -E remove gmon.out
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      "${PROJECT_BINARY_DIR}/bench/${profile_target}.log"
+    COMMAND ${CMAKE_COMMAND} -E remove gmon.out "$<TARGET_FILE_NAME:${bench_target}>.gmon"
+    WORKING_DIRECTORY ${work_dir}
     DEPENDS ${bench_target}
     COMMENT "Profiling ${target_name} -> ${profile_target}.log")
 

--- a/bench/copy_if_exists.cmake
+++ b/bench/copy_if_exists.cmake
@@ -1,0 +1,3 @@
+if(EXISTS "${SRC}")
+  file(COPY_FILE "${SRC}" "${DST}")
+endif()


### PR DESCRIPTION
## Summary

Refactors the benchmark profiling setup in CMake to isolate execution working directories per benchmark target and handle environment-specific `gmon` file output formats (e.g., on FreeBSD). CI workflows are updated to copy profiling logs from the new `build/bench` output directory.

## Key Changes

* **Isolated Benchmark Directories**: Updated `add_profile_target` in `bench/CMakeLists.txt` to create and use a dedicated working directory (`${PROJECT_BINARY_DIR}/bench/${target_name}`) for each benchmark run.
* **Gprof Output Compatibility**: Added `bench/copy_if_exists.cmake` to handle fallback logic where systems emit `<exec_name>.gmon` instead of the standard `gmon.out`.
* **CI Log Path Updates**: Adjusted artifact paths across Linux and Windows CI workflows to collect profiling logs from `build/bench/`.
* **CMake Requirement Bump**: Bumped `cmake_minimum_required` to version `3.21` in [CMakeLists.txt](https://github.com/koron/cmigemo/compare/bench-on-freebsd?expand=1) to support `file(COPY_FILE)`.
* **Formatting**: Refactored long custom commands in CMake for better readability.